### PR TITLE
Six fixes from PR #3 + review follow-ups

### DIFF
--- a/frontend/src/lib/components/DirectivesTab.svelte
+++ b/frontend/src/lib/components/DirectivesTab.svelte
@@ -12,6 +12,7 @@
     { id: 'sitemaps', label: () => t('directives.sitemaps') },
     { id: 'sitemap_only', label: () => t('directives.sitemapOnly') },
     { id: 'in_both', label: () => t('directives.inBoth') },
+    { id: 'crawl_only', label: () => t('directives.crawlOnly') },
   ];
 
   let hasSitemaps = $state(true); // optimistic default
@@ -59,6 +60,8 @@
     <SitemapCoverageURLs {sessionId} filter="sitemap_only" onerror={(msg) => onerror?.(msg)} />
   {:else if subView === 'in_both'}
     <SitemapCoverageURLs {sessionId} filter="in_both" onerror={(msg) => onerror?.(msg)} />
+  {:else if subView === 'crawl_only'}
+    <SitemapCoverageURLs {sessionId} filter="crawl_only" onerror={(msg) => onerror?.(msg)} />
   {/if}
 </div>
 

--- a/frontend/src/lib/components/SitemapCoverageURLs.svelte
+++ b/frontend/src/lib/components/SitemapCoverageURLs.svelte
@@ -38,7 +38,11 @@
   }
 
   const title = $derived(
-    filter === 'sitemap_only' ? t('directives.sitemapOnly') : t('directives.inBoth'),
+    filter === 'sitemap_only'
+      ? t('directives.sitemapOnly')
+      : filter === 'crawl_only'
+        ? t('directives.crawlOnly')
+        : t('directives.inBoth'),
   );
 
   let exporting = $state(false);

--- a/frontend/src/lib/components/charts/HBarChart.svelte
+++ b/frontend/src/lib/components/charts/HBarChart.svelte
@@ -1,18 +1,29 @@
 <script>
   import { fmtN, a11yKeydown } from '../../utils.js';
 
-  let { bars = [], maxValue = 0, barHeight = 32, gap = 6 } = $props();
+  let { bars = [], maxValue = 0, barHeight = 32, gap = 6, labelWidth = 180 } = $props();
 
   const effectiveMax = $derived(maxValue > 0 ? maxValue : Math.max(...bars.map((b) => b.value), 1));
   const svgH = $derived(bars.length * (barHeight + gap));
+  const barStartX = $derived(labelWidth + 10);
+  const barMaxW = $derived(600 - barStartX - 60);
+
+  function truncate(s, max) {
+    if (!s) return '';
+    return s.length > max ? s.slice(0, max - 1) + '…' : s;
+  }
+
+  // With barHeight=32 and typical font size, ~24 chars fit comfortably in 180px.
+  const labelMaxChars = $derived(Math.floor(labelWidth / 7.5));
 </script>
 
 {#if bars.length > 0}
   <svg class="chart-svg" viewBox="0 0 600 {svgH}" preserveAspectRatio="xMinYMin meet">
     {#each bars as bar, i}
-      {@const barW = effectiveMax > 0 ? (bar.value / effectiveMax) * 440 : 0}
+      {@const barW = effectiveMax > 0 ? (bar.value / effectiveMax) * barMaxW : 0}
       {@const y = i * (barHeight + gap)}
       {@const colorClass = bar.color || 'chart-bar-accent'}
+      {@const display = truncate(bar.label, labelMaxChars)}
       {#if bar.onclick}
         <g
           class="chart-bar-clickable"
@@ -21,34 +32,36 @@
           onclick={() => bar.onclick()}
           onkeydown={a11yKeydown(() => bar.onclick())}
         >
-          <text x="90" y={y + barHeight / 2 + 5} text-anchor="end" class="chart-label"
-            >{bar.label}</text
+          <text x={labelWidth} y={y + barHeight / 2 + 5} text-anchor="end" class="chart-label"
+            >{display}<title>{bar.label}</title></text
           >
           <rect
-            x="100"
+            x={barStartX}
             {y}
             width={Math.max(barW, 2)}
             height={barHeight}
             rx="4"
             class="chart-bar {colorClass}"
           />
-          <text x={104 + barW} y={y + barHeight / 2 + 5} class="chart-value">{fmtN(bar.value)}</text
+          <text x={barStartX + 4 + barW} y={y + barHeight / 2 + 5} class="chart-value"
+            >{fmtN(bar.value)}</text
           >
         </g>
       {:else}
         <g>
-          <text x="90" y={y + barHeight / 2 + 5} text-anchor="end" class="chart-label"
-            >{bar.label}</text
+          <text x={labelWidth} y={y + barHeight / 2 + 5} text-anchor="end" class="chart-label"
+            >{display}<title>{bar.label}</title></text
           >
           <rect
-            x="100"
+            x={barStartX}
             {y}
             width={Math.max(barW, 2)}
             height={barHeight}
             rx="4"
             class="chart-bar {colorClass}"
           />
-          <text x={104 + barW} y={y + barHeight / 2 + 5} class="chart-value">{fmtN(bar.value)}</text
+          <text x={barStartX + 4 + barW} y={y + barHeight / 2 + 5} class="chart-value"
+            >{fmtN(bar.value)}</text
           >
         </g>
       {/if}

--- a/frontend/src/lib/components/reports/SitemapReport.svelte
+++ b/frontend/src/lib/components/reports/SitemapReport.svelte
@@ -26,7 +26,7 @@
         value: s.crawled_only,
         color: 'var(--warning)',
         label: t('report.sitemap.crawledOnly'),
-        onclick: () => nav('overview'),
+        onclick: () => nav('directives/crawl_only'),
       });
     if (s.sitemap_only > 0)
       segs.push({
@@ -73,8 +73,8 @@
           class="stat-card stat-card-link"
           role="button"
           tabindex="0"
-          onclick={() => nav('overview')}
-          onkeydown={a11yKeydown(() => nav('overview'))}
+          onclick={() => nav('directives/crawl_only')}
+          onkeydown={a11yKeydown(() => nav('directives/crawl_only'))}
         >
           <div class="stat-value text-warning">{fmtN(sitemap.crawled_only || 0)}</div>
           <div class="stat-label">{t('report.sitemap.crawledOnly')}</div>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -526,6 +526,7 @@
   "directives.sitemaps": "Sitemaps",
   "directives.sitemapOnly": "Sitemap only",
   "directives.inBoth": "In both",
+  "directives.crawlOnly": "Crawl only",
   "pagerank.topPages": "Top Pages",
   "pagerank.byDirectory": "By Directory",
   "pagerank.distribution": "Distribution",

--- a/frontend/src/lib/i18n/fr.json
+++ b/frontend/src/lib/i18n/fr.json
@@ -526,6 +526,7 @@
   "directives.sitemaps": "Sitemaps",
   "directives.sitemapOnly": "Sitemap uniquement",
   "directives.inBoth": "Crawl et sitemap",
+  "directives.crawlOnly": "Crawl uniquement",
   "pagerank.topPages": "Top pages",
   "pagerank.byDirectory": "Par répertoire",
   "pagerank.distribution": "Distribution",

--- a/internal/interlinking/dedup.go
+++ b/internal/interlinking/dedup.go
@@ -2,6 +2,7 @@ package interlinking
 
 import (
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/SEObserver/crawlobserver/internal/storage"
@@ -45,6 +46,73 @@ var trackingParams = map[string]bool{
 	"utm_medium":   true,
 	"utm_source":   true,
 	"utm_term":     true,
+}
+
+// paginationQueryParams lists query parameters that indicate a paginated variant
+// of a main page. A page with any of these set to a value > "1" is a paginated
+// duplicate and should be skipped for content similarity analysis.
+var paginationQueryParams = map[string]bool{
+	"page":   true,
+	"paged":  true, // WordPress
+	"p":      true, // WordPress, but also generic "product id" — context-aware check below
+	"_page":  true,
+	"pg":     true,
+	"start":  true, // offset-based
+	"offset": true,
+	"from":   true,
+	"skip":   true,
+}
+
+// paginationPathPattern matches path-based pagination like /page/2, /p/3, /section/page/4.
+// Matches "/page/<N>" or "/p/<N>" where N > 1.
+var paginationPathPattern = regexp.MustCompile(`(?i)/(page|p|pagina|strana|seite)/([2-9]|[1-9][0-9]+)(/|$)`)
+
+// IsPaginatedURL returns true if the URL looks like a paginated variant of
+// another page (e.g. ?page=3, /page/2). Page 1 (or missing page param) is the
+// canonical page and is NOT considered paginated.
+func IsPaginatedURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+
+	// Path-based pagination
+	if paginationPathPattern.MatchString(u.Path) {
+		return true
+	}
+
+	// Query-based pagination
+	for key, values := range u.Query() {
+		lowerKey := strings.ToLower(key)
+		if !paginationQueryParams[lowerKey] {
+			continue
+		}
+		// "p" is ambiguous (WordPress post ID vs page number).
+		// Only treat as pagination if the value is a small integer > 1.
+		for _, v := range values {
+			if v == "" || v == "1" || v == "0" {
+				continue
+			}
+			// Must be a pure integer (pagination values are always integers)
+			isInt := true
+			for _, c := range v {
+				if c < '0' || c > '9' {
+					isInt = false
+					break
+				}
+			}
+			if !isInt {
+				continue
+			}
+			// Small positive integer → almost certainly pagination
+			// (large integers are more likely IDs; cap at reasonable max page count)
+			if len(v) <= 4 { // up to 9999 pages
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // NormalizeURL strips known tracking parameters and normalizes trailing slashes.
@@ -100,6 +168,15 @@ func NormalizeURL(rawURL string) string {
 //     canonical/clean URL, then highest PageRank).
 func DeduplicatePages(pageMeta map[string]storage.PageMetadata) map[string]bool {
 	skip := make(map[string]bool)
+
+	// Phase 0: skip paginated variants (page 2, 3, ...).
+	// These are not meaningful targets for internal linking suggestions —
+	// the main page is the canonical entry point.
+	for rawURL := range pageMeta {
+		if IsPaginatedURL(rawURL) {
+			skip[rawURL] = true
+		}
+	}
 
 	// Phase 1: skip pages with a non-self canonical pointing to another crawled page
 	for rawURL, meta := range pageMeta {

--- a/internal/interlinking/dedup_test.go
+++ b/internal/interlinking/dedup_test.go
@@ -348,3 +348,97 @@ func TestDeduplicatePages_RootSlashNormalization(t *testing.T) {
 		t.Errorf("expected 1 root-slash duplicate skipped, got %d", skipped)
 	}
 }
+
+func TestIsPaginatedURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		// Path-based pagination — positives
+		{"path /page/2", "https://example.com/blog/page/2", true},
+		{"path /page/2 trailing slash", "https://example.com/blog/page/2/", true},
+		{"path /page/10", "https://example.com/blog/page/10", true},
+		{"path /p/3", "https://example.com/news/p/3", true},
+		{"path /pagina/2 (es/it)", "https://example.com/blog/pagina/2", true},
+		{"path /seite/4 (de)", "https://example.com/blog/seite/4", true},
+		{"path /strana/5 (sl/cs)", "https://example.com/blog/strana/5", true},
+		{"path uppercase /Page/2", "https://example.com/blog/Page/2", true},
+
+		// Path-based — negatives
+		{"path /page/1 is canonical", "https://example.com/blog/page/1", false},
+		{"path without page segment", "https://example.com/blog/post-2", false},
+		{"path /pages/2 (plural, not pagination)", "https://example.com/pages/2", false},
+
+		// Query-based — positives
+		{"query ?page=2", "https://example.com/blog?page=2", true},
+		{"query ?paged=4 (WP)", "https://example.com/blog?paged=4", true},
+		{"query ?p=2 (small int)", "https://example.com/?p=2", true},
+		{"query ?_page=3", "https://example.com/list?_page=3", true},
+		{"query ?pg=2", "https://example.com/list?pg=2", true},
+		{"query ?offset=20", "https://example.com/list?offset=20", true},
+		{"query ?start=10", "https://example.com/list?start=10", true},
+		{"query ?from=50", "https://example.com/list?from=50", true},
+		{"query ?skip=100", "https://example.com/list?skip=100", true},
+		{"query uppercase ?PAGE=2", "https://example.com/blog?PAGE=2", true},
+		{"query mixed with other params", "https://example.com/list?cat=shoes&page=3", true},
+		{"query large but ≤9999", "https://example.com/list?page=9999", true},
+
+		// Query-based — negatives (canonical / non-pagination)
+		{"query ?page=1 is canonical", "https://example.com/blog?page=1", false},
+		{"query ?page=0 is canonical", "https://example.com/blog?page=0", false},
+		{"query ?page= empty", "https://example.com/blog?page=", false},
+		{"query ?p=1234567 (WP post ID)", "https://example.com/?p=1234567", false},
+		{"query non-integer ?page=abc", "https://example.com/blog?page=abc", false},
+		{"query ?other=2 not pagination param", "https://example.com/blog?other=2", false},
+		{"no query no path pagination", "https://example.com/blog", false},
+
+		// Edge cases
+		{"empty url", "", false},
+		{"malformed url", "://broken", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsPaginatedURL(tc.url)
+			if got != tc.want {
+				t.Errorf("IsPaginatedURL(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeduplicatePages_SkipsPaginated(t *testing.T) {
+	meta := map[string]storage.PageMetadata{
+		"https://example.com/blog":             {PageRank: 10, CanonicalSelf: true},
+		"https://example.com/blog?page=2":      {PageRank: 5, CanonicalSelf: true},
+		"https://example.com/blog?page=3":      {PageRank: 4, CanonicalSelf: true},
+		"https://example.com/blog/page/4":      {PageRank: 3, CanonicalSelf: true},
+		"https://example.com/blog?page=1":      {PageRank: 9, CanonicalSelf: true},
+		"https://example.com/post?p=1234567":   {PageRank: 6, CanonicalSelf: true},
+	}
+
+	skip := DeduplicatePages(meta)
+
+	wantSkipped := map[string]bool{
+		"https://example.com/blog?page=2": true,
+		"https://example.com/blog?page=3": true,
+		"https://example.com/blog/page/4": true,
+	}
+	wantKept := []string{
+		"https://example.com/blog",
+		"https://example.com/blog?page=1",
+		"https://example.com/post?p=1234567",
+	}
+
+	for url := range wantSkipped {
+		if !skip[url] {
+			t.Errorf("expected %q to be skipped (paginated), but it was kept", url)
+		}
+	}
+	for _, url := range wantKept {
+		if skip[url] {
+			t.Errorf("expected %q to be kept, but it was skipped", url)
+		}
+	}
+}

--- a/internal/normalizer/url.go
+++ b/internal/normalizer/url.go
@@ -57,6 +57,18 @@ func Normalize(rawURL string) (string, error) {
 	}
 
 	normalized = removeTrackingParams(normalized)
+
+	// Ensure root URLs have a trailing slash so that "https://example.com"
+	// and "https://example.com/" are treated as the same page (they are,
+	// per RFC 3986 — the empty path at the root is equivalent to "/").
+	// Without this, a bare-host seed and any relative link resolved by
+	// url.ResolveReference (which produces "host/") create two separate
+	// dedup entries for what is a single page.
+	if u, perr := url.Parse(normalized); perr == nil && u.Host != "" && u.Path == "" {
+		u.Path = "/"
+		normalized = u.String()
+	}
+
 	return normalized, nil
 }
 

--- a/internal/normalizer/url_test.go
+++ b/internal/normalizer/url_test.go
@@ -27,7 +27,10 @@ func TestNormalize(t *testing.T) {
 		{"remove gclid", "https://example.com/?gclid=xyz&q=test", "https://example.com/?q=test", false},
 		{"remove all tracking params", "https://example.com/?utm_source=x&utm_medium=y&utm_campaign=z&utm_term=a&utm_content=b&fbclid=c&gclid=d", "https://example.com/", false},
 		{"empty string", "", "", false},
-		{"whitespace", "  https://example.com  ", "https://example.com", false},
+		{"whitespace", "  https://example.com  ", "https://example.com/", false},
+		{"bare host gets trailing slash", "https://example.com", "https://example.com/", false},
+		{"bare host with port gets trailing slash", "https://example.com:8080", "https://example.com:8080/", false},
+		{"non-root path is unchanged", "https://example.com/page", "https://example.com/page", false},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/handlers_sessions.go
+++ b/internal/server/handlers_sessions.go
@@ -1116,8 +1116,8 @@ func (s *Server) handleSitemapCoverageURLs(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	filter := r.URL.Query().Get("filter")
-	if filter != "sitemap_only" && filter != "in_both" {
-		writeError(w, http.StatusBadRequest, "filter must be sitemap_only or in_both")
+	if filter != "sitemap_only" && filter != "in_both" && filter != "crawl_only" {
+		writeError(w, http.StatusBadRequest, "filter must be sitemap_only, in_both, or crawl_only")
 		return
 	}
 	limit, offset := clampPagination(queryInt(r, "limit", 100), queryInt(r, "offset", 0))

--- a/internal/storage/clickhouse_compare.go
+++ b/internal/storage/clickhouse_compare.go
@@ -61,10 +61,10 @@ func (s *Store) ComparePages(ctx context.Context, sessionA, sessionB, diffType s
 	case "added":
 		query = `
 			SELECT b.url,
-				0, '', '', false, 0, 0, 0, '', '',
+				toUInt16(0), '', '', false, toUInt32(0), toUInt16(0), toFloat64(0), '', '',
 				b.status_code, b.title, b.canonical, b.is_indexable, b.word_count, b.depth, b.pagerank, b.meta_description, b.h1[1]
-			FROM crawlobserver.pages FINAL b
-			LEFT JOIN crawlobserver.pages FINAL a ON a.url = b.url AND a.crawl_session_id = ? AND (a.final_url = '' OR a.final_url = a.url)
+			FROM crawlobserver.pages AS b FINAL
+			LEFT JOIN crawlobserver.pages AS a FINAL ON a.url = b.url AND a.crawl_session_id = ? AND (a.final_url = '' OR a.final_url = a.url)
 			WHERE b.crawl_session_id = ? AND a.url = '' AND (b.final_url = '' OR b.final_url = b.url)
 			ORDER BY b.url
 			LIMIT ? OFFSET ?`
@@ -90,9 +90,9 @@ func (s *Store) ComparePages(ctx context.Context, sessionA, sessionB, diffType s
 		query = `
 			SELECT a.url,
 				a.status_code, a.title, a.canonical, a.is_indexable, a.word_count, a.depth, a.pagerank, a.meta_description, a.h1[1],
-				0, '', '', false, 0, 0, 0, '', ''
-			FROM crawlobserver.pages FINAL a
-			LEFT JOIN crawlobserver.pages FINAL b ON a.url = b.url AND b.crawl_session_id = ? AND (b.final_url = '' OR b.final_url = b.url)
+				toUInt16(0), '', '', false, toUInt32(0), toUInt16(0), toFloat64(0), '', ''
+			FROM crawlobserver.pages AS a FINAL
+			LEFT JOIN crawlobserver.pages AS b FINAL ON a.url = b.url AND b.crawl_session_id = ? AND (b.final_url = '' OR b.final_url = b.url)
 			WHERE a.crawl_session_id = ? AND b.url = '' AND (a.final_url = '' OR a.final_url = a.url)
 			ORDER BY a.url
 			LIMIT ? OFFSET ?`
@@ -119,8 +119,8 @@ func (s *Store) ComparePages(ctx context.Context, sessionA, sessionB, diffType s
 			SELECT a.url,
 				a.status_code, a.title, a.canonical, a.is_indexable, a.word_count, a.depth, a.pagerank, a.meta_description, a.h1[1],
 				b.status_code, b.title, b.canonical, b.is_indexable, b.word_count, b.depth, b.pagerank, b.meta_description, b.h1[1]
-			FROM crawlobserver.pages FINAL a
-			INNER JOIN crawlobserver.pages FINAL b ON a.url = b.url AND b.crawl_session_id = ? AND (b.final_url = '' OR b.final_url = b.url)
+			FROM crawlobserver.pages AS a FINAL
+			INNER JOIN crawlobserver.pages AS b FINAL ON a.url = b.url AND b.crawl_session_id = ? AND (b.final_url = '' OR b.final_url = b.url)
 			WHERE a.crawl_session_id = ? AND (a.final_url = '' OR a.final_url = a.url) AND (
 				a.status_code != b.status_code OR
 				a.title != b.title OR

--- a/internal/storage/clickhouse_integration_test.go
+++ b/internal/storage/clickhouse_integration_test.go
@@ -60,7 +60,7 @@ func TestGetExpiredDomains_NoData(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()
 
-	result, err := s.GetExpiredDomains(ctx, "00000000-0000-0000-0000-000000000000", 100, 0)
+	result, err := s.GetExpiredDomains(ctx, "00000000-0000-0000-0000-000000000000", 100, 0, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestGetExpiredDomains_FullScenario(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	// Test: get all expired domains
-	result, err := s.GetExpiredDomains(ctx, sessionID, 100, 0)
+	result, err := s.GetExpiredDomains(ctx, sessionID, 100, 0, false)
 	if err != nil {
 		t.Fatalf("GetExpiredDomains: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestGetExpiredDomains_Pagination(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	// Page 1: limit=2, offset=0 → should get domain-a.com (3) and domain-b.com (2)
-	page1, err := s.GetExpiredDomains(ctx, sessionID, 2, 0)
+	page1, err := s.GetExpiredDomains(ctx, sessionID, 2, 0, false)
 	if err != nil {
 		t.Fatalf("page 1: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestGetExpiredDomains_Pagination(t *testing.T) {
 	}
 
 	// Page 2: limit=2, offset=2 → should get domain-c.com (1)
-	page2, err := s.GetExpiredDomains(ctx, sessionID, 2, 2)
+	page2, err := s.GetExpiredDomains(ctx, sessionID, 2, 2, false)
 	if err != nil {
 		t.Fatalf("page 2: %v", err)
 	}

--- a/internal/storage/clickhouse_sessions.go
+++ b/internal/storage/clickhouse_sessions.go
@@ -475,22 +475,26 @@ func (s *Store) SessionAudit(ctx context.Context, sessionID string) (*AuditResul
 
 	// --- Content audit ---
 	content := &AuditContent{}
+	// All content-quality counts (title, meta, h1, thin content) are restricted to
+	// HTML pages with status 2xx — images, PDFs, JS, CSS etc. have no <title>
+	// by design and must not inflate "missing" buckets. The `total` here is the
+	// count of auditable HTML pages; raw page totals are reported elsewhere.
 	row := s.conn.QueryRow(ctx, `
 		SELECT count() AS total,
-			countIf(content_type LIKE '%html%') AS html_pages,
-			countIf(title = '') AS title_missing,
-			countIf(title_length > 60) AS title_too_long,
-			countIf(title_length > 0 AND title_length < 30) AS title_too_short,
-			countIf(meta_description = '') AS meta_desc_missing,
-			countIf(meta_desc_length > 160) AS meta_desc_too_long,
-			countIf(meta_desc_length > 0 AND meta_desc_length < 70) AS meta_desc_too_short,
-			countIf(length(h1) = 0) AS h1_missing,
-			countIf(length(h1) > 1) AS h1_multiple,
-			countIf(word_count < 100) AS thin_under_100,
-			countIf(word_count >= 100 AND word_count < 300) AS thin_100_300,
-			sum(images_count) AS images_total,
-			sum(images_no_alt) AS images_no_alt_total,
-			countIf(images_no_alt > 0) AS pages_with_images_no_alt
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300) AS html_pages,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND title = '') AS title_missing,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND title_length > 60) AS title_too_long,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND title_length > 0 AND title_length < 30) AS title_too_short,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND meta_description = '') AS meta_desc_missing,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND meta_desc_length > 160) AS meta_desc_too_long,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND meta_desc_length > 0 AND meta_desc_length < 70) AS meta_desc_too_short,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND length(h1) = 0) AS h1_missing,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND length(h1) > 1) AS h1_multiple,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND word_count < 100) AS thin_under_100,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND word_count >= 100 AND word_count < 300) AS thin_100_300,
+			sumIf(images_count, content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300) AS images_total,
+			sumIf(images_no_alt, content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300) AS images_no_alt_total,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND images_no_alt > 0) AS pages_with_images_no_alt
 		FROM crawlobserver.pages FINAL WHERE crawl_session_id = ? AND `+notRedirectedFilter, sessionID)
 	if err := row.Scan(
 		&content.Total, &content.HTMLPages,
@@ -519,14 +523,18 @@ func (s *Store) SessionAudit(ctx context.Context, sessionID string) (*AuditResul
 	result.Content = content
 
 	// --- Technical audit ---
+	// Indexability and canonical metrics only make sense on HTML 2xx pages —
+	// images, PDFs, CSS/JS don't carry <meta robots> or <link rel=canonical>.
+	// Redirects, response times and errors are meaningful for any resource type
+	// and are counted across the full crawl.
 	tech := &AuditTechnical{}
 	techRow := s.conn.QueryRow(ctx, `
 		SELECT
-			countIf(is_indexable = true) AS indexable,
-			countIf(is_indexable = false) AS non_indexable,
-			countIf(canonical_is_self = true) AS canonical_self,
-			countIf(canonical != '' AND canonical_is_self = false) AS canonical_other,
-			countIf(canonical = '') AS canonical_missing,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND is_indexable = true) AS indexable,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND is_indexable = false) AS non_indexable,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND canonical_is_self = true) AS canonical_self,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND canonical != '' AND canonical_is_self = false) AS canonical_other,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND canonical = '') AS canonical_missing,
 			countIf(length(redirect_chain) > 0) AS has_redirect,
 			countIf(length(redirect_chain) > 2) AS redirect_chains_over_2,
 			countIf(fetch_duration_ms < 200) AS response_fast,
@@ -545,10 +553,13 @@ func (s *Store) SessionAudit(ctx context.Context, sessionID string) (*AuditResul
 		return nil, fmt.Errorf("audit technical: %w", err)
 	}
 
-	// Noindex reasons
+	// Noindex reasons — restricted to HTML 2xx so non-HTML resources don't
+	// show up as "noindex because non-HTML" and inflate the top reasons.
 	niRows, err := s.conn.Query(ctx, `
 		SELECT index_reason, count() AS cnt FROM crawlobserver.pages FINAL
-		WHERE crawl_session_id = ? AND is_indexable = false AND index_reason != '' AND `+notRedirectedFilter+`
+		WHERE crawl_session_id = ? AND content_type LIKE '%html%'
+			AND status_code >= 200 AND status_code < 300
+			AND is_indexable = false AND index_reason != '' AND `+notRedirectedFilter+`
 		GROUP BY index_reason ORDER BY cnt DESC`, sessionID)
 	if err == nil {
 		defer niRows.Close()
@@ -595,12 +606,14 @@ func (s *Store) SessionAudit(ctx context.Context, sessionID string) (*AuditResul
 		return nil, fmt.Errorf("audit links: %w", err)
 	}
 
-	// Pages link distribution
+	// Pages link distribution — restricted to HTML 2xx pages. Non-HTML
+	// resources (images, PDFs, JS, CSS...) never contain anchor tags, so
+	// reporting them as "pages with no outgoing links" is misleading.
 	pageDistRow := s.conn.QueryRow(ctx, `
 		SELECT
-			countIf(internal_links_out = 0) AS pages_no_internal_out,
-			countIf(internal_links_out > 100) AS pages_high_internal_out,
-			countIf(external_links_out = 0) AS pages_no_external
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND internal_links_out = 0) AS pages_no_internal_out,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND internal_links_out > 100) AS pages_high_internal_out,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND external_links_out = 0) AS pages_no_external
 		FROM crawlobserver.pages FINAL WHERE crawl_session_id = ? AND `+notRedirectedFilter, sessionID)
 	if err := pageDistRow.Scan(&links.PagesNoInternalOut, &links.PagesHighInternalOut, &links.PagesNoExternal); err != nil {
 		applog.Warnf("audit", "scan link distribution: %v", err)
@@ -705,17 +718,30 @@ func (s *Store) SessionAudit(ctx context.Context, sessionID string) (*AuditResul
 	}
 
 	if sitemaps.TotalSitemapURLs > 0 {
+		// Sitemap coverage is meaningful only for HTML 2xx pages — sitemaps
+		// list indexable content, not resources (images, JS, CSS, PDFs).
+		// Counting raw crawled URLs in "Crawl only" would lump every image
+		// into the bucket and break the coverage signal.
 		var inBoth uint64
 		ibRow := s.conn.QueryRow(ctx, `
 			SELECT count() FROM (
 				SELECT DISTINCT loc FROM crawlobserver.sitemap_urls WHERE crawl_session_id = ?
 			) AS sm WHERE sm.loc IN (
-				SELECT url FROM crawlobserver.pages FINAL WHERE crawl_session_id = ? AND `+notRedirectedFilter+`
+				SELECT url FROM crawlobserver.pages FINAL
+				WHERE crawl_session_id = ?
+					AND content_type LIKE '%html%'
+					AND status_code >= 200 AND status_code < 300
+					AND `+notRedirectedFilter+`
 			)`, sessionID, sessionID)
 		if ibRow.Scan(&inBoth) == nil {
 			sitemaps.InBoth = inBoth
 			var totalCrawled uint64
-			tcRow := s.conn.QueryRow(ctx, `SELECT count() FROM crawlobserver.pages FINAL WHERE crawl_session_id = ? AND `+notRedirectedFilter, sessionID)
+			tcRow := s.conn.QueryRow(ctx, `
+				SELECT count() FROM crawlobserver.pages FINAL
+				WHERE crawl_session_id = ?
+					AND content_type LIKE '%html%'
+					AND status_code >= 200 AND status_code < 300
+					AND `+notRedirectedFilter, sessionID)
 			if err := tcRow.Scan(&totalCrawled); err != nil {
 				applog.Warnf("audit", "scan total crawled for sitemap coverage: %v", err)
 			}
@@ -726,12 +752,14 @@ func (s *Store) SessionAudit(ctx context.Context, sessionID string) (*AuditResul
 	result.Sitemaps = sitemaps
 
 	// --- International audit ---
+	// hreflang, lang and schema markup only live on HTML pages; count on
+	// HTML 2xx only so resources don't dilute the denominator.
 	intl := &AuditInternational{}
 	intlRow := s.conn.QueryRow(ctx, `
 		SELECT
-			countIf(length(hreflang) > 0) AS pages_with_hreflang,
-			countIf(lang != '') AS pages_with_lang,
-			countIf(length(schema_types) > 0) AS pages_with_schema
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND length(hreflang) > 0) AS pages_with_hreflang,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND lang != '') AS pages_with_lang,
+			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND length(schema_types) > 0) AS pages_with_schema
 		FROM crawlobserver.pages FINAL WHERE crawl_session_id = ? AND `+notRedirectedFilter, sessionID)
 	if err := intlRow.Scan(&intl.PagesWithHreflang, &intl.PagesWithLang, &intl.PagesWithSchema); err != nil {
 		applog.Warnf("audit", "scan international stats: %v", err)

--- a/internal/storage/clickhouse_sessions.go
+++ b/internal/storage/clickhouse_sessions.go
@@ -480,7 +480,7 @@ func (s *Store) SessionAudit(ctx context.Context, sessionID string) (*AuditResul
 	// by design and must not inflate "missing" buckets. The `total` here is the
 	// count of auditable HTML pages; raw page totals are reported elsewhere.
 	row := s.conn.QueryRow(ctx, `
-		SELECT count() AS total,
+		SELECT countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300) AS total,
 			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300) AS html_pages,
 			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND title = '') AS title_missing,
 			countIf(content_type LIKE '%html%' AND status_code >= 200 AND status_code < 300 AND title_length > 60) AS title_too_long,
@@ -511,7 +511,9 @@ func (s *Store) SessionAudit(ctx context.Context, sessionID string) (*AuditResul
 	dupRow := s.conn.QueryRow(ctx, `
 		SELECT sum(cnt - 1) FROM (
 			SELECT title, count() AS cnt FROM crawlobserver.pages FINAL
-			WHERE crawl_session_id = ? AND title != '' AND `+notRedirectedFilter+`
+			WHERE crawl_session_id = ? AND content_type LIKE '%html%'
+				AND status_code >= 200 AND status_code < 300
+				AND title != '' AND `+notRedirectedFilter+`
 			GROUP BY title HAVING cnt > 1
 		)`, sessionID)
 	var titleDups int64

--- a/internal/storage/clickhouse_sessions_audit_scope_test.go
+++ b/internal/storage/clickhouse_sessions_audit_scope_test.go
@@ -1,0 +1,48 @@
+//go:build integration
+
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSessionAudit_ContentCountsOnlyHTML2xxPages(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	sid := "dddddddd-eeee-ffff-0000-444444444444"
+	t.Cleanup(func() { cleanupRedirectTestSession(t, s, sid) })
+	cleanupRedirectTestSession(t, s, sid)
+
+	now := time.Now()
+	pages := []PageRow{
+		{CrawlSessionID: sid, URL: "https://example.com/html-ok-1", FinalURL: "", StatusCode: 200, ContentType: "text/html", Title: "Duplicate Title", TitleLength: 15, MetaDescription: "Short meta", MetaDescLength: 10, H1: []string{"H1"}, WordCount: 80, CrawledAt: now},
+		{CrawlSessionID: sid, URL: "https://example.com/html-ok-2", FinalURL: "", StatusCode: 200, ContentType: "text/html", Title: "Duplicate Title", TitleLength: 15, MetaDescription: "Another short meta", MetaDescLength: 18, H1: []string{"H1"}, WordCount: 120, CrawledAt: now},
+		{CrawlSessionID: sid, URL: "https://example.com/html-404", FinalURL: "", StatusCode: 404, ContentType: "text/html", Title: "", TitleLength: 0, MetaDescription: "", MetaDescLength: 0, H1: nil, WordCount: 0, CrawledAt: now},
+		{CrawlSessionID: sid, URL: "https://example.com/file.pdf", FinalURL: "", StatusCode: 200, ContentType: "application/pdf", Title: "", TitleLength: 0, MetaDescription: "", MetaDescLength: 0, H1: nil, WordCount: 0, CrawledAt: now},
+	}
+	insertTestPages(t, s, sid, pages)
+
+	audit, err := s.SessionAudit(ctx, sid)
+	if err != nil {
+		t.Fatalf("SessionAudit: %v", err)
+	}
+
+	if audit.Content.Total != 2 {
+		t.Fatalf("content.Total: expected 2 HTML 2xx pages, got %d", audit.Content.Total)
+	}
+	if audit.Content.HTMLPages != 2 {
+		t.Fatalf("content.HTMLPages: expected 2, got %d", audit.Content.HTMLPages)
+	}
+	if audit.Content.TitleDuplicates != 1 {
+		t.Fatalf("content.TitleDuplicates: expected 1 duplicate among HTML 2xx pages, got %d", audit.Content.TitleDuplicates)
+	}
+	if audit.Content.TitleMissing != 0 {
+		t.Fatalf("content.TitleMissing: expected 0 after excluding HTML 404/PDF, got %d", audit.Content.TitleMissing)
+	}
+	if audit.Content.H1Missing != 0 {
+		t.Fatalf("content.H1Missing: expected 0 after excluding HTML 404/PDF, got %d", audit.Content.H1Missing)
+	}
+}

--- a/internal/storage/clickhouse_sitemaps.go
+++ b/internal/storage/clickhouse_sitemaps.go
@@ -183,7 +183,10 @@ func (s *Store) GetSitemapURLs(ctx context.Context, sessionID, sitemapURL string
 }
 
 // GetSitemapCoverageURLs returns paginated sitemap URLs filtered by coverage type.
-// filter must be "sitemap_only" (in sitemap but not crawled) or "in_both" (in sitemap and crawled).
+// filter must be "sitemap_only" (in sitemap but not crawled), "in_both" (in sitemap and
+// crawled), or "crawl_only" (crawled HTML 2xx pages absent from the sitemap).
+// Crawl-side comparisons are restricted to HTML 2xx pages so that images, PDFs, JS
+// and CSS don't appear as "missing from sitemap" — sitemaps list indexable content only.
 func (s *Store) GetSitemapCoverageURLs(ctx context.Context, sessionID, filter string, limit, offset int) ([]SitemapURLRow, error) {
 	var query string
 	switch filter {
@@ -192,15 +195,36 @@ func (s *Store) GetSitemapCoverageURLs(ctx context.Context, sessionID, filter st
 			SELECT DISTINCT '' AS crawl_session_id, '' AS sitemap_url, su.loc, su.lastmod, su.changefreq, su.priority
 			FROM crawlobserver.sitemap_urls su
 			WHERE su.crawl_session_id = ?
-			  AND su.loc NOT IN (SELECT url FROM crawlobserver.pages FINAL WHERE crawl_session_id = ? AND ` + notRedirectedFilter + `)
+			  AND su.loc NOT IN (
+				SELECT url FROM crawlobserver.pages FINAL
+				WHERE crawl_session_id = ?
+					AND content_type LIKE '%html%'
+					AND status_code >= 200 AND status_code < 300
+					AND ` + notRedirectedFilter + `)
 			ORDER BY su.loc LIMIT ? OFFSET ?`
 	case "in_both":
 		query = `
 			SELECT DISTINCT '' AS crawl_session_id, '' AS sitemap_url, su.loc, su.lastmod, su.changefreq, su.priority
 			FROM crawlobserver.sitemap_urls su
 			WHERE su.crawl_session_id = ?
-			  AND su.loc IN (SELECT url FROM crawlobserver.pages FINAL WHERE crawl_session_id = ? AND ` + notRedirectedFilter + `)
+			  AND su.loc IN (
+				SELECT url FROM crawlobserver.pages FINAL
+				WHERE crawl_session_id = ?
+					AND content_type LIKE '%html%'
+					AND status_code >= 200 AND status_code < 300
+					AND ` + notRedirectedFilter + `)
 			ORDER BY su.loc LIMIT ? OFFSET ?`
+	case "crawl_only":
+		query = `
+			SELECT DISTINCT '' AS crawl_session_id, '' AS sitemap_url, p.url AS loc, '' AS lastmod, '' AS changefreq, '' AS priority
+			FROM crawlobserver.pages AS p FINAL
+			WHERE p.crawl_session_id = ?
+			  AND p.content_type LIKE '%html%'
+			  AND p.status_code >= 200 AND p.status_code < 300
+			  AND (p.final_url = '' OR p.final_url = p.url)
+			  AND p.url NOT IN (
+				SELECT DISTINCT loc FROM crawlobserver.sitemap_urls WHERE crawl_session_id = ?)
+			ORDER BY p.url LIMIT ? OFFSET ?`
 	default:
 		return nil, fmt.Errorf("invalid coverage filter: %s", filter)
 	}


### PR DESCRIPTION
## Summary

Re-applies the six bug fixes proposed by @fulanolive741 in #3 (CH compare aliases, root URL trailing slash, audit HTML 2xx, sitemap crawl_only, paginated dedup, HBarChart overflow), plus follow-up corrections found during local review.

The original PR #3 cannot be merged as-is because it lives on an external fork and CI doesn't run on it; this PR re-applies the same six commits unchanged on a branch in this repo so the workflow runs, with one extra commit (`ff86c72`) that fixes the issues found in review.

## What's added on top of #3

Single follow-up commit `ff86c72`:

1. `internal/normalizer/url_test.go` — fixed the `whitespace` test case that PR #3 broke (expected value was `"https://example.com"`, real output is now `"https://example.com/"`). Added explicit cases for the new bare-host trailing-slash contract.
2. `frontend/src/lib/i18n/en.json` — added missing `directives.crawlOnly` (PR #3 only added it in `fr.json`).
3. `internal/interlinking/dedup_test.go` — table-driven tests for the new `IsPaginatedURL` function (positive/negative patterns, multilingual paths, WP post-id false-positive guard, edge cases) + integration test on `DeduplicatePages`.
4. `internal/storage/clickhouse_sessions.go` (line 480) — replaced `count() AS total` with the same HTML-2xx `countIf(...)` used for the other audit metrics, to align the value with the comment PR #3 added (which claimed "auditable HTML pages" but the code still ran a raw count). **Behaviour change**: `audit.Content.Total` now returns the HTML-2xx-auditable count instead of the raw crawl total — fixes a visual inconsistency in `ContentReport.svelte` (donut center label was larger than the sum of segments).
5. `internal/storage/clickhouse_sessions.go` (lines 511-516) — extended the HTML-2xx scope to the `dupRow` query for duplicate titles, which PR #3 had missed. Without it, PDFs with empty titles could be counted as duplicates.
6. `internal/storage/clickhouse_sessions_audit_scope_test.go` (new, `//go:build integration`) — locks down the HTML-2xx scoping with an end-to-end test (2 HTML 2xx duplicates + 1 HTML 404 + 1 PDF 200, asserts Total/HTMLPages/TitleDuplicates/TitleMissing/H1Missing).
7. `internal/storage/clickhouse_integration_test.go` — pre-existing bug, surfaced by the new audit_scope test: `GetExpiredDomains` already had a 5-arg signature on `main` (`nsOnly bool` added in an earlier commit) but the integration tests still called it with 4 args, so they no longer compiled with `-tags=integration`. Updated the four call sites to pass `false`.

## Test plan

- [ ] `go test ./...` passes (unit)
- [ ] `go vet ./...` is clean (modulo the pre-existing `updater_test.go` warning)
- [ ] `go test -tags=integration ./internal/storage` compiles and passes when ClickHouse is available
- [ ] Frontend builds (`npm run build`) and `directives/crawl_only` sub-view renders the localized label in both `en` and `fr`
- [ ] `Compare` view loads on a recent ClickHouse without the `code 62` syntax error
- [ ] Crawl a site exposing both `/` and bare host; verify only one entry is kept
- [ ] Audit donut center label matches the sum of segments after the scope change
- [ ] `Sitemap coverage` → `Crawl only` opens the URL list (not the overview)

## Closing PR #3

Closing #3 in favour of this PR; full credit to @fulanolive741 for the six original commits.
