### PR TITLE
Expose public API URL in server info

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -47,6 +47,8 @@ resources:
 server:
   host: 127.0.0.1
   port: 8899
+  # Public URL shown in API docs when deployed behind HTTPS/reverse proxy
+  public_url: ""
   # Basic auth credentials (CHANGE THESE before exposing to the internet)
   username: admin
   password: crawlobserver

--- a/frontend/src/lib/components/APIManagementPage.svelte
+++ b/frontend/src/lib/components/APIManagementPage.svelte
@@ -324,7 +324,7 @@
   ];
 
   function buildRefMarkdown() {
-    const base = serverInfo?.api_url || 'http://localhost:9090/api';
+    const base = serverInfo?.api_url || `${window.location.origin}/api`;
     let md = `# CrawlObserver REST API\n\nBase URL: ${base}\n`;
     if (serverInfo?.has_auth) {
       md += `Auth: Basic auth (user: ${serverInfo.username}) or X-API-Key header\n`;

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,6 +137,7 @@ type ResourcesConfig struct {
 type ServerConfig struct {
 	Host              string          `mapstructure:"host"`
 	Port              int             `mapstructure:"port"`
+	PublicURL         string          `mapstructure:"public_url"`
 	Username          string          `mapstructure:"username"`
 	Password          string          `mapstructure:"password"`
 	SQLitePath        string          `mapstructure:"sqlite_path"`
@@ -234,6 +235,7 @@ func SetDefaults() {
 
 	viper.SetDefault("server.host", "127.0.0.1")
 	viper.SetDefault("server.port", 8899)
+	viper.SetDefault("server.public_url", "")
 	viper.SetDefault("server.username", "admin")
 	viper.SetDefault("server.password", "")
 	viper.SetDefault("server.sqlite_path", "crawlobserver.db")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -555,7 +555,7 @@ func apiDiscoveryFilePath() string {
 }
 
 func (s *Server) writeAPIDiscoveryFile() {
-	data, err := json.MarshalIndent(s.serverInfoPayload(), "", "  ")
+	data, err := json.MarshalIndent(s.serverInfoPayload(nil), "", "  ")
 	if err != nil {
 		applog.Warnf("server", "Could not marshal API discovery file: %v", err)
 		return
@@ -597,11 +597,11 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleServerInfo(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, s.serverInfoPayload())
+	writeJSON(w, s.serverInfoPayload(r))
 }
 
-func (s *Server) serverInfoPayload() map[string]interface{} {
-	addr := fmt.Sprintf("http://%s:%d", s.cfg.Server.Host, s.cfg.Server.Port)
+func (s *Server) serverInfoPayload(r *http.Request) map[string]interface{} {
+	addr := s.publicBaseURL(r)
 	info := map[string]interface{}{
 		"api_url":  addr + "/api",
 		"host":     s.cfg.Server.Host,
@@ -609,6 +609,36 @@ func (s *Server) serverInfoPayload() map[string]interface{} {
 		"has_auth": s.cfg.Server.Username != "" && s.cfg.Server.Password != "",
 	}
 	return info
+}
+
+func (s *Server) publicBaseURL(r *http.Request) string {
+	if publicURL := strings.TrimRight(strings.TrimSpace(s.cfg.Server.PublicURL), "/"); publicURL != "" {
+		return publicURL
+	}
+	if r != nil {
+		scheme := "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
+		if forwardedProto := firstForwardedValue(r.Header.Get("X-Forwarded-Proto")); forwardedProto != "" {
+			scheme = forwardedProto
+		}
+		host := r.Host
+		if forwardedHost := firstForwardedValue(r.Header.Get("X-Forwarded-Host")); forwardedHost != "" {
+			host = forwardedHost
+		}
+		if host != "" && host != "0.0.0.0" {
+			return scheme + "://" + host
+		}
+	}
+	return fmt.Sprintf("http://%s:%d", s.cfg.Server.Host, s.cfg.Server.Port)
+}
+
+func firstForwardedValue(value string) string {
+	if value == "" {
+		return ""
+	}
+	return strings.TrimSpace(strings.Split(value, ",")[0])
 }
 
 func (s *Server) handleTheme(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4524,6 +4524,46 @@ func TestHandleServerInfo_Success(t *testing.T) {
 	}
 }
 
+func TestHandleServerInfo_UsesPublicURL(t *testing.T) {
+	srv, handler, _ := newTestServer(t)
+	srv.cfg.Server.PublicURL = "https://crawlobserver.example.com/"
+
+	req := authRequest(httptest.NewRequest("GET", "/api/server-info", nil))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	decodeJSON(t, rec, &resp)
+	if resp["api_url"] != "https://crawlobserver.example.com/api" {
+		t.Errorf("expected public api_url, got %v", resp["api_url"])
+	}
+}
+
+func TestHandleServerInfo_UsesForwardedHeaders(t *testing.T) {
+	_, handler, _ := newTestServer(t)
+
+	req := authRequest(httptest.NewRequest("GET", "/api/server-info", nil))
+	req.Host = "127.0.0.1:8899"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "crawlobserver.example.com")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	decodeJSON(t, rec, &resp)
+	if resp["api_url"] != "https://crawlobserver.example.com/api" {
+		t.Errorf("expected forwarded api_url, got %v", resp["api_url"])
+	}
+}
+
 // --- handleUpdateTheme ---
 
 func TestHandleUpdateTheme_BadBody(t *testing.T) {


### PR DESCRIPTION
## Summary

- adds configurable `server.public_url` support
- returns externally usable `api_url` from `/api/server-info` using public URL or forwarded headers
- updates the API management UI to show the server-reported API URL instead of an internal bind address

## Validation

- npm run --prefix frontend build
- git diff --check
- Go tests were not run locally because `go` is not installed in PATH.
