### PR TITLE
Add scoped users and project access

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -29,6 +29,8 @@
     createBackup,
     getSetupStatus,
     getTelemetry,
+    getCurrentUser,
+    logout,
   } from './lib/api.js';
   import { initTelemetry, trackPageView, trackEvent, disableTelemetry } from './lib/telemetry.js';
   import { fmtSize } from './lib/utils.js';
@@ -49,6 +51,7 @@
   import SessionDetailPage from './lib/components/SessionDetailPage.svelte';
   import ProjectPage from './lib/components/ProjectPage.svelte';
   import AnnouncementBanner from './lib/components/AnnouncementBanner.svelte';
+  import LoginPage from './lib/components/LoginPage.svelte';
 
   // --- Named constants ---
   // STATS_REFRESH_MS removed — stats refresh is now SSE signal-driven
@@ -65,6 +68,9 @@
   let showOnboarding = $state(false);
   let onboardingStartStep = $state(1); // 1 = full wizard, 3 = telemetry only (existing users)
   let setupChecked = $state(false);
+  let authChecked = $state(false);
+  let currentUser = $state(null);
+  let isAdmin = $derived(currentUser?.role === 'admin');
 
   // --- Crawl state ---
   let sessions = $state([]);
@@ -155,6 +161,7 @@
 
   // --- Global Stats ---
   function openGlobalStats() {
+    if (!isAdmin) return;
     currentView = 'stats';
     selectedSession = null;
     selectedProject = null;
@@ -163,6 +170,7 @@
 
   // --- API page ---
   function openAPI() {
+    if (!isAdmin) return;
     currentView = 'api';
     selectedSession = null;
     selectedProject = null;
@@ -170,6 +178,7 @@
   }
 
   function openLogs() {
+    if (!isAdmin) return;
     currentView = 'logs';
     selectedSession = null;
     selectedProject = null;
@@ -202,6 +211,7 @@
 
   // --- Settings ---
   function openSettings() {
+    if (!isAdmin) return;
     currentView = 'settings';
     selectedSession = null;
     selectedProject = null;
@@ -229,6 +239,10 @@
   }
 
   async function navigateTo(path, queryFilters = {}) {
+    if (!isAdmin && ['/settings', '/stats', '/api', '/logs', '/new-crawl'].includes(path)) {
+      path = '/';
+      queryFilters = {};
+    }
     pushURL(path, queryFilters);
     routeVersion++;
     await applyRoute();
@@ -249,6 +263,10 @@
           : route.page === 'new-crawl'
             ? 'new-crawl'
             : route.page;
+      if (!isAdmin && ['settings', 'stats', 'api', 'logs', 'new-crawl'].includes(currentView)) {
+        goHome();
+        return;
+      }
 
       if (route.page === 'project') {
         currentView = 'project';
@@ -408,6 +426,7 @@
 
   // --- Update check polling ---
   function startUpdatePoll() {
+    if (updatePollTimer) return;
     let attempts = 0;
     updatePollTimer = setInterval(async () => {
       attempts++;
@@ -429,7 +448,48 @@
       }
     }, UPDATE_POLL_MS);
   }
-  startUpdatePoll();
+
+  async function checkAuth() {
+    try {
+      currentUser = await getCurrentUser();
+    } catch {
+      currentUser = null;
+    } finally {
+      authChecked = true;
+    }
+  }
+
+  async function handleLogin(user) {
+    currentUser = user;
+    authChecked = true;
+    error = null;
+    await bootApp();
+  }
+
+  async function handleLogout() {
+    try {
+      await logout();
+    } catch {
+      // Continue locally if the server session was already gone.
+    }
+    currentUser = null;
+    sessions = [];
+    projects = [];
+    selectedSession = null;
+    selectedProject = null;
+    globalStats = null;
+    systemStats = null;
+    if (systemStatsInterval) {
+      clearInterval(systemStatsInterval);
+      systemStatsInterval = null;
+    }
+    if (updatePollTimer) {
+      clearInterval(updatePollTimer);
+      updatePollTimer = null;
+    }
+    sse.disconnectAll();
+    pushURL('/');
+  }
 
   async function doBackupAndUpdate() {
     updatingApp = true;
@@ -557,6 +617,7 @@
   }
 
   async function loadStorageStats() {
+    if (!isAdmin) return;
     try {
       storageStats = await getStorageStats();
     } catch (e) {
@@ -565,6 +626,7 @@
   }
 
   async function loadSystemStats() {
+    if (!isAdmin) return;
     try {
       systemStats = await getSystemStats();
     } catch (e) {
@@ -602,15 +664,23 @@
       // If setup endpoint fails (e.g. CLI mode), proceed normally
     }
     setupChecked = true;
+    await checkAuth();
+    if (!currentUser) {
+      loading = false;
+      return;
+    }
     await bootApp();
   }
 
   async function bootApp() {
-    startSystemStatsPolling();
+    if (isAdmin) {
+      startSystemStatsPolling();
+      startUpdatePoll();
+    }
     getProjects()
       .then((p) => (projects = p))
       .catch(() => {});
-    if (!globalStats)
+    if (isAdmin && !globalStats)
       getGlobalStats()
         .then((gs) => (globalStats = gs))
         .catch(() => {});
@@ -646,7 +716,14 @@
 
 {#if showOnboarding}
   <OnboardingWizard startStep={onboardingStartStep} oncomplete={onOnboardingComplete} />
-{:else if setupChecked}
+{:else if !setupChecked || !authChecked}
+  <main class="app-loading-shell" aria-live="polite" aria-busy="true">
+    <div class="app-loading-mark" aria-hidden="true"></div>
+    <span>Loading {theme.app_name || 'CrawlObserver'}...</span>
+  </main>
+{:else if !currentUser}
+  <LoginPage appName={theme.app_name} onlogin={handleLogin} />
+{:else}
   <a class="skip-link" href="#main-content">{t('app.skipToContent')}</a>
   <div class="layout">
     <div class="drag-bar"><span class="drag-bar-title">{theme.app_name}</span></div>
@@ -672,6 +749,8 @@
       ongohome={goHome}
       oncreateproject={handleCreateProject}
       onviewallprojects={openAllProjects}
+      {currentUser}
+      onlogout={handleLogout}
       {appVersion}
     />
 
@@ -687,7 +766,7 @@
           </div>
         {/if}
 
-        {#if updateInfo && !updateDismissed}
+        {#if isAdmin && updateInfo && !updateDismissed}
           <div class="alert alert-info">
             <span>{t('app.updateAvailable', { version: updateInfo.latest_version })}</span>
             <div class="flex-center-gap">
@@ -712,7 +791,7 @@
 
         <AnnouncementBanner />
 
-        {#if sessionRecordingActive}
+        {#if isAdmin && sessionRecordingActive}
           <div class="alert alert-session-recording">
             <span>{t('settings.sessionRecordingBanner')}</span>
           </div>
@@ -725,6 +804,7 @@
             onsave={handleSettingsSave}
             oncancel={handleSettingsCancel}
             onsessionrecording={(v) => (sessionRecordingActive = v)}
+            onprojectschanged={(p) => (projects = p)}
           />
         {:else if currentView === 'stats'}
           <GlobalStatsPage onerror={(msg) => (error = msg)} />
@@ -742,7 +822,7 @@
           <AllProjectsPage
             onerror={(msg) => (error = msg)}
             onselectproject={selectProject}
-            oncreateproject={() => navigateTo('/new-crawl')}
+            oncreateproject={isAdmin ? () => navigateTo('/new-crawl') : undefined}
           />
         {:else if currentView === 'api'}
           <APIManagementPage
@@ -771,7 +851,9 @@
               onerror={(msg) => (error = msg)}
               onselectsession={selectSession}
               ongohome={goHome}
-              onnewcrawl={() => navigateTo('/new-crawl', { project: selectedProject?.id })}
+              onnewcrawl={isAdmin
+                ? () => navigateTo('/new-crawl', { project: selectedProject?.id })
+                : undefined}
               onprojectrenamed={async (id) => {
                 projects = await getProjects();
                 selectedProject = projects.find((p) => p.id === id) || selectedProject;
@@ -781,6 +863,7 @@
                 goHome();
               }}
               onpushurl={(u) => pushURL(u)}
+              {currentUser}
             />
           {/key}
         {:else if currentView === 'home'}
@@ -794,8 +877,9 @@
             onstop={handleStop}
             onresume={openResumeModal}
             ondelete={handleDelete}
-            onnewcrawl={() => navigateTo('/new-crawl')}
+            onnewcrawl={isAdmin ? () => navigateTo('/new-crawl') : undefined}
             onrefresh={loadSessions}
+            {isAdmin}
           />
         {:else if currentView === 'session' && selectedSession}
           {#key selectedSession.ID + '-' + routeVersion}
@@ -811,10 +895,10 @@
               initialDetailUrl={routeDetailUrl}
               initialSubView={routeSubView}
               onerror={(msg) => (error = msg)}
-              onstop={handleStop}
-              onresume={openResumeModal}
-              onretry={openRetryModal}
-              ondelete={handleDelete}
+              onstop={isAdmin ? handleStop : undefined}
+              onresume={isAdmin ? openResumeModal : undefined}
+              onretry={isAdmin ? openRetryModal : undefined}
+              ondelete={isAdmin ? handleDelete : undefined}
               onrefresh={() => selectSession(selectedSession)}
               oncompare={(id) => navigateTo(`/compare?a=${id}`)}
               onnavigate={navigateTo}
@@ -894,3 +978,32 @@
     />
   {/if}
 {/if}
+
+<style>
+  .app-loading-shell {
+    min-height: 100vh;
+    width: 100%;
+    display: grid;
+    place-items: center;
+    align-content: center;
+    gap: 14px;
+    background: var(--bg);
+    color: var(--text-muted);
+    font-size: 14px;
+  }
+
+  .app-loading-mark {
+    width: 36px;
+    height: 36px;
+    border: 3px solid var(--border);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: app-loading-spin 0.8s linear infinite;
+  }
+
+  @keyframes app-loading-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+</style>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -129,6 +129,46 @@ async function fetchJSON(path, options = {}) {
   return JSON.parse(text);
 }
 
+export async function login(username, password) {
+  return fetchJSON('/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+}
+
+export async function logout() {
+  return fetchJSON('/auth/logout', { method: 'POST' });
+}
+
+export async function getCurrentUser() {
+  return fetchJSON('/auth/me');
+}
+
+export async function getUsers() {
+  return fetchJSON('/users');
+}
+
+export async function createUser(user) {
+  return fetchJSON('/users', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(user),
+  });
+}
+
+export async function updateUser(id, user) {
+  return fetchJSON(`/users/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(user),
+  });
+}
+
+export async function deleteUser(id) {
+  return fetchJSON(`/users/${id}`, { method: 'DELETE' });
+}
+
 /** @returns {Promise<Session[]>} */
 export async function getSessions() {
   return fetchJSON('/sessions');

--- a/frontend/src/lib/components/APIManagementPage.svelte
+++ b/frontend/src/lib/components/APIManagementPage.svelte
@@ -1,5 +1,11 @@
 <script>
-  import { getProjects, getAPIKeys, createAPIKey, deleteAPIKey, getServerInfo } from '../api.js';
+  import {
+    getProjects,
+    getAPIKeys,
+    createAPIKey,
+    deleteAPIKey,
+    getServerInfo,
+  } from '../api.js';
   import { timeAgo, copyToClipboard } from '../utils.js';
   import { t } from '../i18n/index.svelte.js';
   import ConfirmModal from './ConfirmModal.svelte';
@@ -72,6 +78,18 @@
   }
 
   const apiRef = [
+    {
+      section: 'Auth',
+      endpoints: [
+        { method: 'POST', path: '/auth/login', desc: 'Log in with a local username/password' },
+        { method: 'POST', path: '/auth/logout', desc: 'Clear the browser session cookie' },
+        {
+          method: 'GET',
+          path: '/auth/me',
+          desc: 'Return the authenticated user or credential scope',
+        },
+      ],
+    },
     {
       section: 'Crawl Sessions',
       endpoints: [
@@ -213,7 +231,11 @@
     {
       section: 'Projects',
       endpoints: [
-        { method: 'GET', path: '/projects', desc: 'List all projects' },
+        {
+          method: 'GET',
+          path: '/projects',
+          desc: 'List visible projects for the current credential',
+        },
         { method: 'POST', path: '/projects', desc: 'Create a project' },
         { method: 'PUT', path: '/projects/{id}', desc: 'Rename a project' },
         { method: 'DELETE', path: '/projects/{id}', desc: 'Delete a project' },
@@ -235,6 +257,19 @@
         { method: 'GET', path: '/api-keys', desc: 'List API keys' },
         { method: 'POST', path: '/api-keys', desc: 'Create an API key' },
         { method: 'DELETE', path: '/api-keys/{id}', desc: 'Revoke an API key' },
+      ],
+    },
+    {
+      section: 'Users',
+      endpoints: [
+        { method: 'GET', path: '/users', desc: 'List local users (admin only)' },
+        { method: 'POST', path: '/users', desc: 'Create a local admin or project-scoped viewer' },
+        {
+          method: 'PUT',
+          path: '/users/{id}',
+          desc: 'Update role, active state, password, or projects',
+        },
+        { method: 'DELETE', path: '/users/{id}', desc: 'Delete a local user' },
       ],
     },
     {

--- a/frontend/src/lib/components/AllProjectsPage.svelte
+++ b/frontend/src/lib/components/AllProjectsPage.svelte
@@ -55,9 +55,11 @@
     <button class="btn btn-sm" onclick={loadProjects} disabled={loading}>
       {loading ? t('common.loading') : t('common.refresh')}
     </button>
-    <button class="btn btn-sm btn-primary" onclick={() => oncreateproject?.()}
-      >{t('projects.newProject')}</button
-    >
+    {#if oncreateproject}
+      <button class="btn btn-sm btn-primary" onclick={() => oncreateproject()}
+        >{t('projects.newProject')}</button
+      >
+    {/if}
   </div>
 </div>
 

--- a/frontend/src/lib/components/LoginPage.svelte
+++ b/frontend/src/lib/components/LoginPage.svelte
@@ -1,0 +1,445 @@
+<script>
+  import { login } from '../api.js';
+
+  let { appName = 'CrawlObserver', onlogin } = $props();
+
+  let username = $state('');
+  let password = $state('');
+  let error = $state('');
+  let loading = $state(false);
+
+  async function submit() {
+    if (!username.trim() || !password || loading) return;
+    loading = true;
+    error = '';
+    try {
+      const user = await login(username.trim(), password);
+      onlogin?.(user);
+    } catch (e) {
+      error = e.message;
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+
+<main class="login-shell">
+  <section class="login-product" aria-label="{appName} overview">
+    <div class="brand-lockup">
+      <div class="brand-mark" aria-hidden="true">
+        <span></span>
+        <span></span>
+        <span></span>
+      </div>
+      <div>
+        <div class="brand-name">{appName}</div>
+        <div class="brand-subtitle">Crawl intelligence workspace</div>
+      </div>
+    </div>
+
+    <div class="product-copy">
+      <p class="product-kicker">Secure console</p>
+      <h1>Monitor crawls, projects, and API access from one controlled workspace.</h1>
+      <p>
+        Sign in to review crawl sessions, project data, rendering status, Search Console signals,
+        and scoped user access.
+      </p>
+    </div>
+
+    <div class="signal-board" aria-hidden="true">
+      <div class="signal-row">
+        <span>Health</span>
+        <strong>Online</strong>
+      </div>
+      <div class="signal-row">
+        <span>Render pool</span>
+        <strong>Ready</strong>
+      </div>
+      <div class="signal-row">
+        <span>API access</span>
+        <strong>Scoped</strong>
+      </div>
+      <div class="signal-meter">
+        <span style="width: 72%"></span>
+      </div>
+    </div>
+  </section>
+
+  <section class="login-card" aria-labelledby="login-title">
+    <div class="login-card-header">
+      <p>Account access</p>
+      <h2 id="login-title">Sign in to continue</h2>
+    </div>
+
+    <form
+      class="login-form"
+      onsubmit={(e) => {
+        e.preventDefault();
+        submit();
+      }}
+    >
+      <div class="field">
+        <label for="login-username">Username</label>
+        <input
+          id="login-username"
+          autocomplete="username"
+          bind:value={username}
+          aria-invalid={error ? 'true' : 'false'}
+        />
+      </div>
+
+      <div class="field">
+        <label for="login-password">Password</label>
+        <input
+          id="login-password"
+          type="password"
+          autocomplete="current-password"
+          bind:value={password}
+          aria-invalid={error ? 'true' : 'false'}
+        />
+      </div>
+
+      {#if error}
+        <div class="login-error" role="alert">{error}</div>
+      {/if}
+
+      <button class="btn btn-primary login-submit" disabled={loading || !username.trim() || !password}>
+        <span>{loading ? 'Signing in...' : 'Sign in'}</span>
+        <span class="submit-arrow" aria-hidden="true">-&gt;</span>
+      </button>
+    </form>
+
+    <div class="login-note">
+      Access is managed by your CrawlObserver administrator. Project-scoped accounts only see
+      assigned projects.
+    </div>
+  </section>
+</main>
+
+<style>
+  .login-shell {
+    min-height: 100vh;
+    display: grid;
+    grid-template-columns: minmax(0, 1.05fr) minmax(360px, 480px);
+    align-items: stretch;
+    background:
+      linear-gradient(135deg, color-mix(in srgb, var(--bg) 92%, #0f766e) 0%, var(--bg) 54%),
+      var(--bg);
+    color: var(--text);
+    padding: 24px;
+    gap: 24px;
+  }
+
+  .login-product {
+    min-height: calc(100vh - 48px);
+    display: grid;
+    align-content: space-between;
+    gap: 32px;
+    padding: clamp(28px, 5vw, 56px);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background:
+      linear-gradient(180deg, color-mix(in srgb, var(--bg-card) 96%, #0f766e) 0%, var(--bg-card) 100%),
+      var(--bg-card);
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+    position: relative;
+  }
+
+  .login-product::after {
+    content: '';
+    position: absolute;
+    inset: auto -20% -1px 18%;
+    height: 42%;
+    background:
+      linear-gradient(90deg, transparent 0 8%, color-mix(in srgb, var(--accent) 18%, transparent) 8% 9%, transparent 9% 100%),
+      linear-gradient(0deg, transparent 0 14%, color-mix(in srgb, #0f766e 18%, transparent) 14% 15%, transparent 15% 100%);
+    background-size:
+      68px 68px,
+      68px 68px;
+    opacity: 0.42;
+    pointer-events: none;
+  }
+
+  .brand-lockup {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    position: relative;
+    z-index: 1;
+  }
+
+  .brand-mark {
+    width: 44px;
+    height: 44px;
+    border-radius: 8px;
+    display: grid;
+    place-items: center;
+    background: var(--accent);
+    box-shadow: 0 16px 34px color-mix(in srgb, var(--accent) 24%, transparent);
+    position: relative;
+  }
+
+  .brand-mark span {
+    position: absolute;
+    width: 22px;
+    height: 3px;
+    border-radius: 999px;
+    background: var(--accent-text);
+  }
+
+  .brand-mark span:nth-child(1) {
+    transform: translateY(-8px);
+  }
+
+  .brand-mark span:nth-child(2) {
+    width: 28px;
+  }
+
+  .brand-mark span:nth-child(3) {
+    transform: translateY(8px);
+    width: 16px;
+  }
+
+  .brand-name {
+    font-family:
+      'Nunito Sans',
+      'Inter',
+      system-ui,
+      sans-serif;
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 1.15;
+  }
+
+  .brand-subtitle {
+    margin-top: 2px;
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+
+  .product-copy {
+    max-width: 660px;
+    position: relative;
+    z-index: 1;
+  }
+
+  .product-kicker {
+    color: var(--accent);
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 12px;
+  }
+
+  .product-copy h1 {
+    font-size: clamp(34px, 5vw, 58px);
+    line-height: 1.03;
+    max-width: 760px;
+    margin: 0;
+    letter-spacing: 0;
+  }
+
+  .product-copy p:not(.product-kicker) {
+    margin-top: 18px;
+    max-width: 580px;
+    color: var(--text-secondary);
+    font-size: 16px;
+    line-height: 1.65;
+  }
+
+  .signal-board {
+    width: min(430px, 100%);
+    position: relative;
+    z-index: 1;
+    display: grid;
+    gap: 1px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--border);
+    box-shadow: var(--shadow);
+  }
+
+  .signal-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 13px 15px;
+    background: color-mix(in srgb, var(--bg-card) 96%, var(--bg));
+    font-size: 13px;
+  }
+
+  .signal-row span {
+    color: var(--text-muted);
+  }
+
+  .signal-row strong {
+    font-weight: 700;
+    color: var(--text);
+  }
+
+  .signal-meter {
+    height: 7px;
+    background: var(--bg-hover);
+  }
+
+  .signal-meter span {
+    display: block;
+    height: 100%;
+    background: linear-gradient(90deg, #0f766e, var(--accent));
+  }
+
+  .login-card {
+    min-height: calc(100vh - 48px);
+    display: grid;
+    align-content: center;
+    gap: 24px;
+    padding: clamp(24px, 5vw, 52px);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-card);
+    box-shadow: var(--shadow-md);
+  }
+
+  .login-card-header p {
+    color: var(--accent);
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 8px;
+  }
+
+  .login-card-header h2 {
+    font-size: 28px;
+    line-height: 1.15;
+    letter-spacing: 0;
+  }
+
+  .login-form {
+    display: grid;
+    gap: 16px;
+  }
+
+  .field {
+    display: grid;
+    gap: 8px;
+  }
+
+  label {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-secondary);
+  }
+
+  input {
+    width: 100%;
+    height: 44px;
+    padding: 0 13px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg-input);
+    color: var(--text);
+    font: inherit;
+    transition:
+      border-color 0.15s,
+      box-shadow 0.15s,
+      background 0.15s;
+  }
+
+  input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-light);
+  }
+
+  input[aria-invalid='true'] {
+    border-color: var(--error);
+  }
+
+  .login-error {
+    padding: 10px 12px;
+    border: 1px solid color-mix(in srgb, var(--error) 28%, transparent);
+    border-radius: var(--radius-sm);
+    background: var(--error-bg);
+    color: var(--error);
+    font-size: 13px;
+  }
+
+  .login-submit {
+    width: 100%;
+    min-height: 44px;
+    justify-content: center;
+    margin-top: 2px;
+  }
+
+  .submit-arrow {
+    font-weight: 700;
+  }
+
+  .login-note {
+    border-top: 1px solid var(--border-light);
+    padding-top: 18px;
+    color: var(--text-muted);
+    font-size: 13px;
+    line-height: 1.55;
+  }
+
+  @media (max-width: 920px) {
+    .login-shell {
+      grid-template-columns: 1fr;
+      padding: 16px;
+    }
+
+    .login-product,
+    .login-card {
+      min-height: auto;
+    }
+
+    .product-copy h1 {
+      font-size: 32px;
+      max-width: 560px;
+    }
+
+    .login-card {
+      align-content: start;
+    }
+  }
+
+  @media (max-width: 560px) {
+    .login-shell {
+      padding: 0;
+      gap: 0;
+      background: var(--bg);
+    }
+
+    .login-product,
+    .login-card {
+      border-radius: 0;
+      border-left: none;
+      border-right: none;
+      box-shadow: none;
+    }
+
+    .login-product {
+      padding: 24px 20px;
+    }
+
+    .login-card {
+      padding: 28px 20px 32px;
+      border-top: none;
+    }
+
+    .product-copy p:not(.product-kicker),
+    .signal-board {
+      display: none;
+    }
+
+    .product-copy h1 {
+      font-size: 26px;
+      line-height: 1.08;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/ProjectPage.svelte
+++ b/frontend/src/lib/components/ProjectPage.svelte
@@ -34,9 +34,11 @@
     onprojectrenamed,
     onprojectdeleted,
     onpushurl,
+    currentUser,
   } = $props();
 
   // --- Local state ---
+  let isAdmin = $derived(currentUser?.role === 'admin');
   let projectTab = $state(initialProjectTab);
   let projSessions = $state([]);
   let projSessionsTotal = $state(0);
@@ -68,6 +70,7 @@
   }
 
   function switchProjectTab(tab) {
+    if (!isAdmin && tab === 'providers') return;
     projectTab = tab;
     // Use "providers" in URL for any provider tab
     const urlTab = tab.startsWith('provider:') ? 'providers' : tab;
@@ -76,11 +79,13 @@
 
   // --- Rename ---
   function startRenameProject() {
+    if (!isAdmin) return;
     renamingProject = true;
     renameValue = project?.name || '';
   }
 
   async function confirmRenameProject() {
+    if (!isAdmin) return;
     const name = renameValue.trim();
     if (name && name !== project?.name) {
       try {
@@ -99,6 +104,7 @@
 
   // --- Delete ---
   function handleDeleteProject() {
+    if (!isAdmin) return;
     showConfirm(
       t('project.deleteProject') + ` "${project?.name}"?`,
       async () => {
@@ -114,6 +120,7 @@
   }
 
   function handleDeleteProjectWithSessions() {
+    if (!isAdmin) return;
     showConfirm(
       t('project.deleteProjectWithSessions') + ` "${project?.name}"?`,
       async () => {
@@ -197,22 +204,24 @@
   {:else}
     <button
       class="inline-btn breadcrumb-active"
-      ondblclick={startRenameProject}
-      title={t('project.doubleClickRename')}>{project.name}</button
+      ondblclick={isAdmin ? startRenameProject : undefined}
+      title={isAdmin ? t('project.doubleClickRename') : undefined}>{project.name}</button
     >
   {/if}
-  <button class="btn btn-primary btn-sm project-new-crawl" onclick={() => onnewcrawl?.()}>
-    <svg
-      viewBox="0 0 24 24"
-      width="16"
-      height="16"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2"
-      ><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg
-    >
-    {t('sessions.newCrawl')}
-  </button>
+  {#if isAdmin}
+    <button class="btn btn-primary btn-sm project-new-crawl" onclick={() => onnewcrawl?.()}>
+      <svg
+        viewBox="0 0 24 24"
+        width="16"
+        height="16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        ><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg
+      >
+      {t('sessions.newCrawl')}
+    </button>
+  {/if}
 </div>
 
 <div class="tab-bar">
@@ -239,7 +248,7 @@
         />{/if}{meta?.label || conn.provider} Data</button
     >
   {/each}
-  {#if providerConnections.length === 0}
+  {#if isAdmin && providerConnections.length === 0}
     <button
       class="tab"
       class:tab-active={projectTab === 'providers'}
@@ -279,36 +288,38 @@
               <td>{fmtN(s.PagesCrawled || 0)}</td>
               <td class="nowrap text-muted text-sm">{s.StartedAt ? timeAgo(s.StartedAt) : '-'}</td>
               <td onclick={(e) => e.stopPropagation()}>
-                <button
-                  class="btn-ghost btn-unlink"
-                  title={t('session.disassociate')}
-                  onclick={() =>
-                    showConfirm(t('session.disassociateConfirm'), async () => {
-                      try {
-                        await disassociateSession(project.id, s.ID);
-                        loadProjectSessions();
-                      } catch (e) {
-                        onerror?.(e.message);
-                      }
-                    })}
-                >
-                  <svg
-                    viewBox="0 0 24 24"
-                    width="14"
-                    height="14"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    ><line x1="18" y1="6" x2="6" y2="18" /><line
-                      x1="6"
-                      y1="6"
-                      x2="18"
-                      y2="18"
-                    /></svg
+                {#if isAdmin}
+                  <button
+                    class="btn-ghost btn-unlink"
+                    title={t('session.disassociate')}
+                    onclick={() =>
+                      showConfirm(t('session.disassociateConfirm'), async () => {
+                        try {
+                          await disassociateSession(project.id, s.ID);
+                          loadProjectSessions();
+                        } catch (e) {
+                          onerror?.(e.message);
+                        }
+                      })}
                   >
-                </button>
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="14"
+                      height="14"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      ><line x1="18" y1="6" x2="6" y2="18" /><line
+                        x1="6"
+                        y1="6"
+                        x2="18"
+                        y2="18"
+                      /></svg
+                    >
+                  </button>
+                {/if}
               </td>
             </tr>
           {/each}
@@ -346,18 +357,20 @@
     {:else}
       <div class="empty-state">
         <p>{t('project.noSessions')}</p>
-        <button class="btn btn-primary mt-md" onclick={() => onnewcrawl?.()}>
-          <svg
-            viewBox="0 0 24 24"
-            width="16"
-            height="16"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            ><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg
-          >
-          {t('sessions.newCrawl')}
-        </button>
+        {#if isAdmin}
+          <button class="btn btn-primary mt-md" onclick={() => onnewcrawl?.()}>
+            <svg
+              viewBox="0 0 24 24"
+              width="16"
+              height="16"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              ><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg
+            >
+            {t('sessions.newCrawl')}
+          </button>
+        {/if}
       </div>
     {/if}
   {:else if projectTab === 'gsc'}
@@ -366,6 +379,7 @@
       initialSubView={gscSubView}
       onerror={(msg) => onerror?.(msg)}
       onpushurl={(u) => onpushurl?.(u)}
+      {isAdmin}
     />
   {:else if projectTab.startsWith('provider:')}
     <ProvidersTab
@@ -374,18 +388,20 @@
       initialSubView={providerSubView}
       onerror={(msg) => onerror?.(msg)}
       onpushurl={(u) => onpushurl?.(u)}
+      {isAdmin}
     />
-  {:else if projectTab === 'providers'}
+  {:else if projectTab === 'providers' && isAdmin}
     <ProvidersTab
       projectId={project.id}
       initialSubView={providerSubView}
       onerror={(msg) => onerror?.(msg)}
       onpushurl={(u) => onpushurl?.(u)}
+      {isAdmin}
     />
   {/if}
 </div>
 
-{#if projectTab === 'sessions'}
+{#if isAdmin && projectTab === 'sessions'}
   <details class="danger-zone">
     <summary>{t('project.dangerZone')}</summary>
     <div class="danger-zone-item">

--- a/frontend/src/lib/components/ProvidersTab.svelte
+++ b/frontend/src/lib/components/ProvidersTab.svelte
@@ -26,6 +26,7 @@
     initialSubView = 'overview',
     onerror,
     onpushurl,
+    isAdmin = false,
   } = $props();
 
   let subView = $state(initialSubView);
@@ -326,6 +327,7 @@
   onDestroy(() => stopPolling());
 
   async function doConnect() {
+    if (!isAdmin) return;
     if (!apiKeyInput || !domainInput) return;
     connecting = true;
     try {
@@ -343,6 +345,7 @@
   let fetchMenuOpen = $state(false);
 
   async function doFetch(dataTypes = [], force = false) {
+    if (!isAdmin) return;
     fetchMenuOpen = false;
     fetchingData = true;
     fetchStatus = { fetching: true, phase: 'starting', rows_so_far: 0 };
@@ -357,6 +360,7 @@
   }
 
   async function doStop() {
+    if (!isAdmin) return;
     try {
       await stopProviderFetch(projectId, provider);
       fetchingData = false;
@@ -369,6 +373,7 @@
   }
 
   async function doDisconnect() {
+    if (!isAdmin) return;
     try {
       await disconnectProvider(projectId, provider);
       stopPolling();
@@ -388,6 +393,7 @@
   }
 
   async function doUpdate() {
+    if (!isAdmin) return;
     if (!settingsDomain) return;
     updating = true;
     try {
@@ -478,6 +484,7 @@
   }
 
   function switchSubView(view) {
+    if (!isAdmin && view === 'settings') return;
     subView = view;
     if (view === 'backlinks') backlinksOffset = 0;
     if (view === 'refdomains') refdomainsOffset = 0;
@@ -496,6 +503,7 @@
     loadSubView(view);
   }
 
+  if (!isAdmin && subView === 'settings') subView = 'overview';
   loadStatus().then(() => {
     if (projectId) loadSubView(subView);
   });
@@ -518,42 +526,46 @@
           {t('providers.domain')} <strong>{status.domain}</strong>
           <span class="prov-provider-tag">({provider})</span>
         </span>
-        <div class="flex-center-gap">
-          {#if fetchingData}
-            <span class="fetch-indicator">
-              <span class="fetch-spinner"></span>
-              {fetchStatus?.phase || t('providers.fetchingPhase')}{fetchStatus?.rows_so_far
-                ? ` — ${fmtN(fetchStatus.rows_so_far)} rows`
-                : '...'}
-            </span>
-            <button class="btn btn-sm text-danger" onclick={doStop}>{t('common.stop')}</button>
-          {:else}
-            <div class="split-btn-wrap">
-              <button class="btn btn-sm" onclick={() => doFetch()}
-                >{t('providers.fetchData')}</button
-              >
-              <button
-                class="btn btn-sm split-btn-arrow"
-                onclick={(e) => {
-                  e.stopPropagation();
-                  fetchMenuOpen = !fetchMenuOpen;
-                }}
-                aria-label="More fetch options"
-              >
-                <svg width="10" height="6" viewBox="0 0 10 6" fill="currentColor"
-                  ><path d="M0 0l5 6 5-6z" /></svg
-                >
-              </button>
-              {#if fetchMenuOpen}
-                <div class="split-btn-menu" role="menu">
-                  <button class="split-btn-item" onclick={() => doFetch([], true)}
-                    >{t('providers.forceRefresh')}</button
-                  >
-                </div>
+        {#if isAdmin || fetchingData}
+          <div class="flex-center-gap">
+            {#if fetchingData}
+              <span class="fetch-indicator">
+                <span class="fetch-spinner"></span>
+                {fetchStatus?.phase || t('providers.fetchingPhase')}{fetchStatus?.rows_so_far
+                  ? ` — ${fmtN(fetchStatus.rows_so_far)} rows`
+                  : '...'}
+              </span>
+              {#if isAdmin}
+                <button class="btn btn-sm text-danger" onclick={doStop}>{t('common.stop')}</button>
               {/if}
-            </div>
-          {/if}
-        </div>
+            {:else}
+              <div class="split-btn-wrap">
+                <button class="btn btn-sm" onclick={() => doFetch()}
+                  >{t('providers.fetchData')}</button
+                >
+                <button
+                  class="btn btn-sm split-btn-arrow"
+                  onclick={(e) => {
+                    e.stopPropagation();
+                    fetchMenuOpen = !fetchMenuOpen;
+                  }}
+                  aria-label="More fetch options"
+                >
+                  <svg width="10" height="6" viewBox="0 0 10 6" fill="currentColor"
+                    ><path d="M0 0l5 6 5-6z" /></svg
+                  >
+                </button>
+                {#if fetchMenuOpen}
+                  <div class="split-btn-menu" role="menu">
+                    <button class="split-btn-item" onclick={() => doFetch([], true)}
+                      >{t('providers.forceRefresh')}</button
+                    >
+                  </div>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/if}
       </div>
     {/if}
 
@@ -588,16 +600,18 @@
         class:pr-subview-active={subView === 'api_calls'}
         onclick={() => switchSubView('api_calls')}>{t('providers.apiCallsTab')}</button
       >
-      <button
-        class="pr-subview-btn"
-        class:pr-subview-active={subView === 'settings'}
-        onclick={() => switchSubView('settings')}>{t('providers.settings')}</button
-      >
+      {#if isAdmin}
+        <button
+          class="pr-subview-btn"
+          class:pr-subview-active={subView === 'settings'}
+          onclick={() => switchSubView('settings')}>{t('providers.settings')}</button
+        >
+      {/if}
     </div>
 
     {#if !status.connected}
       <!-- Disconnected: locked previews to create desire -->
-      {#if subView === 'settings'}
+      {#if isAdmin && subView === 'settings'}
         <div class="prov-empty">
           <h3 class="prov-connect-title">{t('providers.connectTitle')}</h3>
           <p class="text-muted text-sm mb-md">{t('providers.connectDesc')}</p>
@@ -640,9 +654,11 @@
             />
           </svg>
           <p class="prov-lock-text">{t('providers.lockCta')}</p>
-          <button class="btn btn-primary" onclick={() => switchSubView('settings')}
-            >{t('providers.connectTitle')}</button
-          >
+          {#if isAdmin}
+            <button class="btn btn-primary" onclick={() => switchSubView('settings')}
+              >{t('providers.connectTitle')}</button
+            >
+          {/if}
         </div>
         <div class="prov-preview-wrapper">
           <div class="prov-preview-blur">
@@ -1266,7 +1282,7 @@
       {:else}
         <div class="chart-empty">
           <p>{t('providers.noTopPages')}</p>
-          {#if !fetchingData}
+          {#if isAdmin && !fetchingData}
             <button
               class="btn btn-primary"
               style="margin-top: 0.75rem"

--- a/frontend/src/lib/components/SettingsPage.svelte
+++ b/frontend/src/lib/components/SettingsPage.svelte
@@ -13,8 +13,9 @@
   import { fmtSize } from '../utils.js';
   import { t, setLocale, getLocale } from '../i18n/index.svelte.js';
   import ConfirmModal from './ConfirmModal.svelte';
+  import UserManagement from './UserManagement.svelte';
 
-  let { initialTheme, onerror, onsave, oncancel, onsessionrecording } = $props();
+  let { initialTheme, onerror, onsave, oncancel, onsessionrecording, onprojectschanged } = $props();
 
   let confirmState = $state(null);
 
@@ -260,6 +261,8 @@
     </div>
   {/if}
 </div>
+
+<UserManagement {onerror} {onprojectschanged} />
 
 <!-- Backups -->
 <div class="page-header section-gap">

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -25,8 +25,12 @@
     ongohome,
     oncreateproject,
     onviewallprojects,
+    currentUser,
+    onlogout,
     appVersion,
   } = $props();
+
+  let isAdmin = $derived(currentUser?.role === 'admin');
 
   let isDark = $derived(
     darkMode === 'auto' ? window.matchMedia('(prefers-color-scheme: dark)').matches : !!darkMode,
@@ -198,28 +202,30 @@
         >
         {#if !collapsed}{t('sidebar.dashboard')}{/if}
       </button>
-      <button
-        class="sidebar-link"
-        class:active={currentView === 'new-crawl'}
-        onclick={() => onnavigate?.('/new-crawl')}
-        title={collapsed ? t('sidebar.newCrawl') : undefined}
-      >
-        <svg
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          ><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="16" /><line
-            x1="8"
-            y1="12"
-            x2="16"
-            y2="12"
-          /></svg
+      {#if isAdmin}
+        <button
+          class="sidebar-link"
+          class:active={currentView === 'new-crawl'}
+          onclick={() => onnavigate?.('/new-crawl')}
+          title={collapsed ? t('sidebar.newCrawl') : undefined}
         >
-        {#if !collapsed}{t('sidebar.newCrawl')}{/if}
-      </button>
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            ><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="16" /><line
+              x1="8"
+              y1="12"
+              x2="16"
+              y2="12"
+            /></svg
+          >
+          {#if !collapsed}{t('sidebar.newCrawl')}{/if}
+        </button>
+      {/if}
       <button
         class="sidebar-link"
         class:active={currentView === 'compare'}
@@ -249,26 +255,28 @@
     <details class="sidebar-details" open>
       <summary class="sidebar-section-title flex-between">
         <span>{t('sidebar.projects')}</span>
-        <button
-          class="sidebar-add-btn"
-          onclick={(e) => {
-            e.stopPropagation();
-            startCreate();
-          }}
-          title={t('sidebar.newProject')}
-        >
-          <svg
-            viewBox="0 0 24 24"
-            width="14"
-            height="14"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            ><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg
+        {#if isAdmin}
+          <button
+            class="sidebar-add-btn"
+            onclick={(e) => {
+              e.stopPropagation();
+              startCreate();
+            }}
+            title={t('sidebar.newProject')}
           >
-        </button>
+            <svg
+              viewBox="0 0 24 24"
+              width="14"
+              height="14"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              ><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg
+            >
+          </button>
+        {/if}
       </summary>
       <div class="sidebar-details-body">
         <div class="sidebar-search">
@@ -280,7 +288,7 @@
             oninput={onSearchInput}
           />
         </div>
-        {#if creatingProject}
+        {#if isAdmin && creatingProject}
           <div class="sidebar-inline-input">
             <input
               type="text"
@@ -375,7 +383,7 @@
       </div>
     {/if}
 
-    {#if systemStats}
+    {#if isAdmin && systemStats}
       <details class="sidebar-details">
         <summary class="sidebar-section-title">{t('sidebar.system')}</summary>
         <div class="sidebar-details-body">
@@ -409,83 +417,85 @@
   <div class="sidebar-section sidebar-section-push">
     {#if !collapsed}<div class="sidebar-section-title">{t('sidebar.general')}</div>{/if}
     <nav class="sidebar-nav">
-      <button
-        class="sidebar-link"
-        class:active={currentView === 'stats'}
-        onclick={() => onopenstats?.()}
-        title={collapsed ? t('sidebar.stats') : undefined}
-      >
-        <svg
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          ><line x1="18" y1="20" x2="18" y2="10" /><line x1="12" y1="20" x2="12" y2="4" /><line
-            x1="6"
-            y1="20"
-            x2="6"
-            y2="14"
-          /></svg
+      {#if isAdmin}
+        <button
+          class="sidebar-link"
+          class:active={currentView === 'stats'}
+          onclick={() => onopenstats?.()}
+          title={collapsed ? t('sidebar.stats') : undefined}
         >
-        {#if !collapsed}{t('sidebar.stats')}{/if}
-      </button>
-      <button
-        class="sidebar-link"
-        class:active={currentView === 'settings'}
-        onclick={() => onopensettings?.()}
-        title={collapsed ? t('sidebar.settings') : undefined}
-      >
-        <svg
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          ><circle cx="12" cy="12" r="3" /><path
-            d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
-          /></svg
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            ><line x1="18" y1="20" x2="18" y2="10" /><line x1="12" y1="20" x2="12" y2="4" /><line
+              x1="6"
+              y1="20"
+              x2="6"
+              y2="14"
+            /></svg
+          >
+          {#if !collapsed}{t('sidebar.stats')}{/if}
+        </button>
+        <button
+          class="sidebar-link"
+          class:active={currentView === 'settings'}
+          onclick={() => onopensettings?.()}
+          title={collapsed ? t('sidebar.settings') : undefined}
         >
-        {#if !collapsed}{t('sidebar.settings')}{/if}
-      </button>
-      <button
-        class="sidebar-link"
-        class:active={currentView === 'logs'}
-        onclick={() => onopenlogs?.()}
-        title={collapsed ? t('sidebar.logs') : undefined}
-      >
-        <svg
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          ><polyline points="4 17 10 11 4 5" /><line x1="12" y1="19" x2="20" y2="19" /></svg
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            ><circle cx="12" cy="12" r="3" /><path
+              d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+            /></svg
+          >
+          {#if !collapsed}{t('sidebar.settings')}{/if}
+        </button>
+        <button
+          class="sidebar-link"
+          class:active={currentView === 'logs'}
+          onclick={() => onopenlogs?.()}
+          title={collapsed ? t('sidebar.logs') : undefined}
         >
-        {#if !collapsed}{t('sidebar.logs')}{/if}
-      </button>
-      <button
-        class="sidebar-link"
-        class:active={currentView === 'api'}
-        onclick={() => onopenapi?.()}
-        title={collapsed ? t('sidebar.api') : undefined}
-      >
-        <svg
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          ><path
-            d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"
-          /></svg
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            ><polyline points="4 17 10 11 4 5" /><line x1="12" y1="19" x2="20" y2="19" /></svg
+          >
+          {#if !collapsed}{t('sidebar.logs')}{/if}
+        </button>
+        <button
+          class="sidebar-link"
+          class:active={currentView === 'api'}
+          onclick={() => onopenapi?.()}
+          title={collapsed ? t('sidebar.api') : undefined}
         >
-        {#if !collapsed}{t('sidebar.api')}{/if}
-      </button>
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            ><path
+              d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"
+            /></svg
+          >
+          {#if !collapsed}{t('sidebar.api')}{/if}
+        </button>
+      {/if}
     </nav>
   </div>
 
@@ -571,7 +581,25 @@
           {/if}
         </svg>
       </button>
+      <button class="sidebar-icon-btn" onclick={() => onlogout?.()} title="Sign out">
+        <svg
+          viewBox="0 0 24 24"
+          width="16"
+          height="16"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          ><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /><polyline
+            points="16 17 21 12 16 7"
+          /><line x1="21" y1="12" x2="9" y2="12" /></svg
+        >
+      </button>
     </div>
+    {#if currentUser && !collapsed}
+      <span class="sidebar-version">{currentUser.username}</span>
+    {/if}
     <a class="sidebar-branding" href="https://www.seobserver.com" target="_blank" rel="noopener">
       {#if isDark}
         <svg viewBox="0 0 224 213" width="16" height="16"

--- a/frontend/src/lib/components/UserManagement.svelte
+++ b/frontend/src/lib/components/UserManagement.svelte
@@ -1,0 +1,334 @@
+<script>
+  import { getProjects, getUsers, createUser, updateUser, deleteUser } from '../api.js';
+  import { t } from '../i18n/index.svelte.js';
+  import ConfirmModal from './ConfirmModal.svelte';
+  import SearchSelect from './SearchSelect.svelte';
+
+  let { onerror, onprojectschanged } = $props();
+
+  let confirmState = $state(null);
+  let projects = $state([]);
+  let users = $state([]);
+  let newUser = $state({
+    username: '',
+    password: '',
+    role: 'viewer',
+    project_ids: [],
+  });
+
+  let adminCount = $derived(users.filter((u) => u.role === 'admin').length);
+
+  function showConfirm(message, onConfirm, opts = {}) {
+    confirmState = { message, onConfirm, ...opts };
+  }
+
+  function isLastAdmin(user) {
+    return user.role === 'admin' && adminCount <= 1;
+  }
+
+  async function loadData() {
+    try {
+      projects = await getProjects();
+      users = await getUsers();
+      onprojectschanged?.(projects);
+    } catch (e) {
+      onerror?.(e.message);
+    }
+  }
+
+  function toggleNewUserProject(projectId) {
+    const ids = new Set(newUser.project_ids || []);
+    if (ids.has(projectId)) ids.delete(projectId);
+    else ids.add(projectId);
+    newUser = { ...newUser, project_ids: [...ids] };
+  }
+
+  async function handleCreateUser() {
+    if (!newUser.username.trim() || !newUser.password) return;
+    try {
+      await createUser({
+        username: newUser.username.trim(),
+        password: newUser.password,
+        role: newUser.role,
+        project_ids: newUser.role === 'viewer' ? newUser.project_ids : [],
+      });
+      newUser = { username: '', password: '', role: 'viewer', project_ids: [] };
+      await loadData();
+    } catch (e) {
+      onerror?.(e.message);
+    }
+  }
+
+  async function handleUpdateUser(user, patch) {
+    if (isLastAdmin(user) && patch.role && patch.role !== 'admin') return;
+    try {
+      await updateUser(user.id, {
+        username: user.username,
+        role: patch.role ?? user.role,
+        active: patch.active ?? user.active,
+        project_ids: patch.project_ids ?? user.project_ids ?? [],
+      });
+      await loadData();
+    } catch (e) {
+      onerror?.(e.message);
+    }
+  }
+
+  function handleDeleteUser(user) {
+    if (isLastAdmin(user)) return;
+    showConfirm(
+      `Delete user "${user.username}"?`,
+      async () => {
+        try {
+          await deleteUser(user.id);
+          await loadData();
+        } catch (e) {
+          onerror?.(e.message);
+        }
+      },
+      { danger: true, confirmLabel: t('common.delete') },
+    );
+  }
+
+  loadData();
+</script>
+
+<div class="page-header section-gap">
+  <h1>Users</h1>
+</div>
+<p class="text-sm text-muted mb-md user-subtitle">
+  Create browser users and scope viewer access to specific projects.
+</p>
+
+<div class="card mb-md">
+  <div class="form-grid">
+    <div class="form-group">
+      <label for="user-name">Username</label>
+      <input id="user-name" type="text" bind:value={newUser.username} placeholder="client" />
+    </div>
+    <div class="form-group">
+      <label for="user-password">Password</label>
+      <input id="user-password" type="password" bind:value={newUser.password} />
+    </div>
+    <div class="form-group">
+      <label for="user-role">Role</label>
+      <SearchSelect
+        id="user-role"
+        bind:value={newUser.role}
+        options={[
+          { value: 'viewer', label: 'Viewer' },
+          { value: 'admin', label: 'Admin' },
+        ]}
+      />
+    </div>
+  </div>
+  {#if newUser.role === 'viewer'}
+    <div class="form-group mt-md">
+      <div class="form-label">Projects</div>
+      <div class="project-checkbox-list">
+        {#each projects as p}
+          <label class="project-checkbox-item">
+            <input
+              type="checkbox"
+              checked={(newUser.project_ids || []).includes(p.id)}
+              onchange={() => toggleNewUserProject(p.id)}
+            />
+            <span>{p.name}</span>
+          </label>
+        {/each}
+      </div>
+    </div>
+  {/if}
+  <div class="mt-md">
+    <button
+      class="btn btn-primary"
+      onclick={handleCreateUser}
+      disabled={!newUser.username.trim() || !newUser.password}>Create user</button
+    >
+  </div>
+</div>
+
+{#if users.length === 0}
+  <div class="card text-center text-muted empty-state">No local users yet.</div>
+{:else}
+  <div class="card card-flush mb-lg">
+    {#each users as u}
+      {@const lastAdmin = isLastAdmin(u)}
+      <div class="user-row">
+        <div class="user-info">
+          <div class="user-name">{u.username}</div>
+          <div class="user-meta">
+            <span class="badge" class:badge-info={u.role === 'admin'}>{u.role}</span>
+            <span class:status-disabled={!u.active}>{u.active ? 'Active' : 'Disabled'}</span>
+            {#if lastAdmin}
+              <span>Last administrator</span>
+            {/if}
+            {#if u.role === 'viewer'}
+              <span>
+                {(u.project_ids || [])
+                  .map((id) => projects.find((p) => p.id === id)?.name || id)
+                  .join(', ') || 'No projects'}
+              </span>
+            {/if}
+          </div>
+          {#if u.role === 'viewer'}
+            <div class="project-checkbox-list project-checkbox-list-sm">
+              {#each projects as p}
+                <label class="project-checkbox-item">
+                  <input
+                    type="checkbox"
+                    checked={(u.project_ids || []).includes(p.id)}
+                    onchange={() => {
+                      const ids = new Set(u.project_ids || []);
+                      if (ids.has(p.id)) ids.delete(p.id);
+                      else ids.add(p.id);
+                      handleUpdateUser(u, { project_ids: [...ids] });
+                    }}
+                  />
+                  <span>{p.name}</span>
+                </label>
+              {/each}
+            </div>
+          {/if}
+        </div>
+        <div class="user-actions">
+          <button
+            class="btn btn-sm"
+            disabled={lastAdmin}
+            title={lastAdmin ? 'Create another admin before changing this role.' : ''}
+            onclick={() =>
+              handleUpdateUser(u, {
+                role: u.role === 'admin' ? 'viewer' : 'admin',
+                project_ids: u.role === 'admin' ? [] : u.project_ids || [],
+              })}
+          >
+            Make {u.role === 'admin' ? 'viewer' : 'admin'}
+          </button>
+          <button class="btn btn-sm" onclick={() => handleUpdateUser(u, { active: !u.active })}>
+            {u.active ? 'Disable' : 'Enable'}
+          </button>
+          <button
+            class="btn btn-sm btn-danger"
+            disabled={lastAdmin}
+            title={lastAdmin ? 'Create another admin before deleting this user.' : ''}
+            onclick={() => handleDeleteUser(u)}>{t('common.delete')}</button
+          >
+        </div>
+      </div>
+    {/each}
+  </div>
+{/if}
+
+{#if confirmState}<ConfirmModal
+    message={confirmState.message}
+    danger={confirmState.danger}
+    confirmLabel={confirmState.confirmLabel}
+    onconfirm={() => {
+      confirmState.onConfirm();
+      confirmState = null;
+    }}
+    oncancel={() => (confirmState = null)}
+  />{/if}
+
+<style>
+  .section-gap {
+    margin-top: 32px;
+  }
+
+  .user-subtitle {
+    max-width: 720px;
+  }
+
+  .form-label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text);
+  }
+
+  .project-checkbox-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 8px;
+    max-height: 180px;
+    overflow: auto;
+    padding: 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-secondary);
+  }
+
+  .project-checkbox-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--text);
+  }
+
+  .project-checkbox-list-sm {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    max-height: 120px;
+    margin-top: 8px;
+    padding: 8px;
+  }
+
+  .status-disabled {
+    color: var(--danger);
+  }
+
+  .user-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 14px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--border);
+    transition: background 0.15s ease;
+  }
+
+  .user-row:last-child {
+    border-bottom: none;
+  }
+
+  .user-row:hover {
+    background: var(--bg-secondary);
+  }
+
+  .user-info {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .user-name {
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 6px;
+  }
+
+  .user-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+
+  .user-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  @media (max-width: 760px) {
+    .user-row {
+      flex-direction: column;
+    }
+
+    .user-actions {
+      flex-wrap: wrap;
+    }
+  }
+</style>

--- a/internal/apikeys/middleware.go
+++ b/internal/apikeys/middleware.go
@@ -4,18 +4,55 @@ import (
 	"context"
 	"crypto/subtle"
 	"net/http"
+	"strings"
 )
+
+const SessionCookieName = "crawlobserver_session"
 
 type contextKey struct{}
 
 type AuthInfo struct {
-	Method    string  // "basic" | "apikey"
-	KeyType   string  // "general" | "project" (only for apikey)
-	ProjectID *string // non-nil only for project keys
+	Method     string  // "basic" | "apikey" | "session"
+	KeyType    string  // "general" | "project" (only for apikey)
+	ProjectID  *string // non-nil only for project keys
+	UserID     string
+	Username   string
+	Role       string
+	ProjectIDs []string
 }
 
 func (a *AuthInfo) IsReadOnly() bool {
-	return a.Method == "apikey" && a.KeyType == "project"
+	return (a.Method == "apikey" && a.KeyType == "project") ||
+		(a.Method == "session" && a.Role != RoleAdmin)
+}
+
+func (a *AuthInfo) IsAdmin() bool {
+	return a == nil ||
+		a.Method == "basic" ||
+		(a.Method == "apikey" && a.KeyType == "general") ||
+		(a.Method == "session" && a.Role == RoleAdmin)
+}
+
+func (a *AuthInfo) AllowedProjectIDs() []string {
+	if a == nil || a.IsAdmin() {
+		return nil
+	}
+	if a.ProjectID != nil {
+		return []string{*a.ProjectID}
+	}
+	return a.ProjectIDs
+}
+
+func (a *AuthInfo) HasProjectAccess(projectID string) bool {
+	if a == nil || a.IsAdmin() {
+		return true
+	}
+	for _, allowed := range a.AllowedProjectIDs() {
+		if allowed == projectID {
+			return true
+		}
+	}
+	return false
 }
 
 func FromContext(ctx context.Context) *AuthInfo {
@@ -45,6 +82,22 @@ func Authenticate(keyStore *Store, basicUser, basicPass string) func(http.Handle
 				return
 			}
 
+			if cookie, err := r.Cookie(SessionCookieName); err == nil && cookie.Value != "" {
+				user, err := keyStore.ValidateUserSession(cookie.Value)
+				if err == nil {
+					info := &AuthInfo{
+						Method:     "session",
+						UserID:     user.ID,
+						Username:   user.Username,
+						Role:       user.Role,
+						ProjectIDs: user.ProjectIDs,
+					}
+					ctx := context.WithValue(r.Context(), contextKey{}, info)
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				}
+			}
+
 			// Fall back to basic auth
 			if basicUser != "" && basicPass != "" {
 				user, pass, ok := r.BasicAuth()
@@ -58,7 +111,9 @@ func Authenticate(keyStore *Store, basicUser, basicPass string) func(http.Handle
 				}
 			}
 
-			w.Header().Set("WWW-Authenticate", `Basic realm="CrawlObserver"`)
+			if !strings.HasPrefix(r.URL.Path, "/api/") {
+				w.Header().Set("WWW-Authenticate", `Basic realm="CrawlObserver"`)
+			}
 			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 		})
 	}

--- a/internal/apikeys/middleware_test.go
+++ b/internal/apikeys/middleware_test.go
@@ -102,8 +102,27 @@ func TestAuthenticateNoCredentials(t *testing.T) {
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", rec.Code)
 	}
+	if rec.Header().Get("WWW-Authenticate") != "" {
+		t.Fatal("did not expect WWW-Authenticate header for API request")
+	}
+}
+
+func TestAuthenticateNoCredentialsHTMLChallenge(t *testing.T) {
+	s := newTestStore(t)
+
+	handler := Authenticate(s, "admin", "secret")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	}))
+
+	req := httptest.NewRequest("GET", "/protected", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
 	if rec.Header().Get("WWW-Authenticate") == "" {
-		t.Fatal("expected WWW-Authenticate header")
+		t.Fatal("expected WWW-Authenticate header for non-API request")
 	}
 }
 

--- a/internal/apikeys/store.go
+++ b/internal/apikeys/store.go
@@ -97,6 +97,45 @@ func NewStore(dbPath string) (*Store, error) {
 	}
 
 	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS users (
+			id TEXT PRIMARY KEY,
+			username TEXT NOT NULL UNIQUE,
+			password_hash TEXT NOT NULL,
+			role TEXT NOT NULL CHECK(role IN ('admin', 'viewer')),
+			active INTEGER DEFAULT 1,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			last_login_at DATETIME
+		)
+	`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("creating users table: %w", err)
+	}
+
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS user_projects (
+			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+			PRIMARY KEY (user_id, project_id)
+		)
+	`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("creating user_projects table: %w", err)
+	}
+
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS user_sessions (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			token_hash TEXT NOT NULL UNIQUE,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			expires_at DATETIME NOT NULL
+		)
+	`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("creating user_sessions table: %w", err)
+	}
+
+	if _, err := db.Exec(`
 		CREATE TABLE IF NOT EXISTS gsc_connections (
 			id TEXT PRIMARY KEY,
 			project_id TEXT NOT NULL UNIQUE REFERENCES projects(id) ON DELETE CASCADE,

--- a/internal/apikeys/users.go
+++ b/internal/apikeys/users.go
@@ -1,0 +1,390 @@
+package apikeys
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	RoleAdmin  = "admin"
+	RoleViewer = "viewer"
+)
+
+type User struct {
+	ID          string     `json:"id"`
+	Username    string     `json:"username"`
+	Role        string     `json:"role"`
+	ProjectIDs  []string   `json:"project_ids"`
+	Active      bool       `json:"active"`
+	CreatedAt   time.Time  `json:"created_at"`
+	LastLoginAt *time.Time `json:"last_login_at"`
+}
+
+type AuthSession struct {
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+func normalizeUsername(username string) string {
+	return strings.ToLower(strings.TrimSpace(username))
+}
+
+func validateRole(role string) error {
+	if role != RoleAdmin && role != RoleViewer {
+		return fmt.Errorf("invalid role: %s", role)
+	}
+	return nil
+}
+
+func hashPassword(password string) (string, error) {
+	if len(password) < 8 {
+		return "", fmt.Errorf("password must be at least 8 characters")
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hash), nil
+}
+
+func tokenHash(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+func generateSessionToken() (string, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func (s *Store) CreateUser(username, password, role string, projectIDs []string) (*User, error) {
+	username = normalizeUsername(username)
+	if username == "" {
+		return nil, fmt.Errorf("username is required")
+	}
+	if err := validateRole(role); err != nil {
+		return nil, err
+	}
+	passwordHash, err := hashPassword(password)
+	if err != nil {
+		return nil, err
+	}
+
+	u := &User{
+		ID:         uuid.New().String(),
+		Username:   username,
+		Role:       role,
+		ProjectIDs: uniqueStrings(projectIDs),
+		Active:     true,
+		CreatedAt:  time.Now().UTC(),
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(`
+		INSERT INTO users (id, username, password_hash, role, active, created_at)
+		VALUES (?, ?, ?, ?, 1, ?)`,
+		u.ID, u.Username, passwordHash, u.Role, u.CreatedAt); err != nil {
+		return nil, err
+	}
+	if err := replaceUserProjects(tx, u.ID, u.ProjectIDs); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
+func (s *Store) ListUsers() ([]User, error) {
+	rows, err := s.db.Query(`
+		SELECT id, username, role, active, created_at, last_login_at
+		FROM users ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []User
+	for rows.Next() {
+		u, err := scanUser(rows)
+		if err != nil {
+			return nil, err
+		}
+		projects, err := s.UserProjectIDs(u.ID)
+		if err != nil {
+			return nil, err
+		}
+		u.ProjectIDs = projects
+		users = append(users, *u)
+	}
+	if users == nil {
+		users = []User{}
+	}
+	return users, rows.Err()
+}
+
+func (s *Store) CountUsersByRole(role string) (int, error) {
+	if err := validateRole(role); err != nil {
+		return 0, err
+	}
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM users WHERE role = ?`, role).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (s *Store) GetUser(id string) (*User, error) {
+	row := s.db.QueryRow(`
+		SELECT id, username, role, active, created_at, last_login_at
+		FROM users WHERE id = ?`, id)
+	u, err := scanUser(row)
+	if err != nil {
+		return nil, err
+	}
+	u.ProjectIDs, err = s.UserProjectIDs(u.ID)
+	if err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
+func (s *Store) GetUserByUsername(username string) (*User, error) {
+	row := s.db.QueryRow(`
+		SELECT id, username, role, active, created_at, last_login_at
+		FROM users WHERE username = ?`, normalizeUsername(username))
+	u, err := scanUser(row)
+	if err != nil {
+		return nil, err
+	}
+	u.ProjectIDs, err = s.UserProjectIDs(u.ID)
+	if err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
+func (s *Store) UpdateUser(id, username, role string, active bool, password *string, projectIDs []string) (*User, error) {
+	username = normalizeUsername(username)
+	if username == "" {
+		return nil, fmt.Errorf("username is required")
+	}
+	if err := validateRole(role); err != nil {
+		return nil, err
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	if password != nil && *password != "" {
+		passwordHash, err := hashPassword(*password)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := tx.Exec(`UPDATE users SET username = ?, password_hash = ?, role = ?, active = ? WHERE id = ?`,
+			username, passwordHash, role, boolInt(active), id); err != nil {
+			return nil, err
+		}
+	} else {
+		if _, err := tx.Exec(`UPDATE users SET username = ?, role = ?, active = ? WHERE id = ?`,
+			username, role, boolInt(active), id); err != nil {
+			return nil, err
+		}
+	}
+	if err := replaceUserProjects(tx, id, uniqueStrings(projectIDs)); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return s.GetUser(id)
+}
+
+func (s *Store) DeleteUser(id string) error {
+	res, err := s.db.Exec(`DELETE FROM users WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("user not found")
+	}
+	return nil
+}
+
+func (s *Store) AuthenticateUser(username, password string) (*User, error) {
+	username = normalizeUsername(username)
+	row := s.db.QueryRow(`
+		SELECT id, username, password_hash, role, active, created_at, last_login_at
+		FROM users WHERE username = ? AND active = 1`, username)
+
+	var passwordHash string
+	var activeInt int
+	u := &User{}
+	if err := row.Scan(&u.ID, &u.Username, &passwordHash, &u.Role, &activeInt, &u.CreatedAt, &u.LastLoginAt); err != nil {
+		return nil, err
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(password)); err != nil {
+		return nil, err
+	}
+	u.Active = activeInt != 0
+	projects, err := s.UserProjectIDs(u.ID)
+	if err != nil {
+		return nil, err
+	}
+	u.ProjectIDs = projects
+	now := time.Now().UTC()
+	if _, err := s.db.Exec(`UPDATE users SET last_login_at = ? WHERE id = ?`, now, u.ID); err != nil {
+		return nil, err
+	}
+	u.LastLoginAt = &now
+	return u, nil
+}
+
+func (s *Store) CreateUserSession(userID string, ttl time.Duration) (string, *AuthSession, error) {
+	if ttl <= 0 {
+		return "", nil, fmt.Errorf("session ttl must be positive")
+	}
+	token, err := generateSessionToken()
+	if err != nil {
+		return "", nil, err
+	}
+	session := &AuthSession{
+		ID:        uuid.New().String(),
+		UserID:    userID,
+		ExpiresAt: time.Now().UTC().Add(ttl),
+	}
+	if _, err := s.db.Exec(`
+		INSERT INTO user_sessions (id, user_id, token_hash, created_at, expires_at)
+		VALUES (?, ?, ?, ?, ?)`,
+		session.ID, session.UserID, tokenHash(token), time.Now().UTC(), session.ExpiresAt); err != nil {
+		return "", nil, err
+	}
+	return token, session, nil
+}
+
+func (s *Store) ValidateUserSession(token string) (*User, error) {
+	if token == "" {
+		return nil, sql.ErrNoRows
+	}
+	now := time.Now().UTC()
+	s.db.Exec(`DELETE FROM user_sessions WHERE expires_at <= ?`, now)
+
+	row := s.db.QueryRow(`
+		SELECT u.id, u.username, u.role, u.active, u.created_at, u.last_login_at
+		FROM user_sessions us
+		JOIN users u ON u.id = us.user_id
+		WHERE us.token_hash = ? AND us.expires_at > ? AND u.active = 1`,
+		tokenHash(token), now)
+	u, err := scanUser(row)
+	if err != nil {
+		return nil, err
+	}
+	u.ProjectIDs, err = s.UserProjectIDs(u.ID)
+	if err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
+func (s *Store) DeleteUserSession(token string) error {
+	_, err := s.db.Exec(`DELETE FROM user_sessions WHERE token_hash = ?`, tokenHash(token))
+	return err
+}
+
+func (s *Store) UserProjectIDs(userID string) ([]string, error) {
+	rows, err := s.db.Query(`SELECT project_id FROM user_projects WHERE user_id = ? ORDER BY project_id`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if ids == nil {
+		ids = []string{}
+	}
+	return ids, rows.Err()
+}
+
+func replaceUserProjects(tx *sql.Tx, userID string, projectIDs []string) error {
+	if _, err := tx.Exec(`DELETE FROM user_projects WHERE user_id = ?`, userID); err != nil {
+		return err
+	}
+	for _, projectID := range uniqueStrings(projectIDs) {
+		if projectID == "" {
+			continue
+		}
+		if _, err := tx.Exec(`INSERT INTO user_projects (user_id, project_id) VALUES (?, ?)`, userID, projectID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type userScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func scanUser(row userScanner) (*User, error) {
+	var activeInt int
+	u := &User{}
+	if err := row.Scan(&u.ID, &u.Username, &u.Role, &activeInt, &u.CreatedAt, &u.LastLoginAt); err != nil {
+		return nil, err
+	}
+	u.Active = activeInt != 0
+	if u.ProjectIDs == nil {
+		u.ProjectIDs = []string{}
+	}
+	return u, nil
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+func boolInt(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
+	"github.com/SEObserver/crawlobserver/internal/apikeys"
 	"github.com/SEObserver/crawlobserver/internal/applog"
 	"github.com/SEObserver/crawlobserver/internal/backup"
 	"github.com/SEObserver/crawlobserver/internal/updater"
@@ -221,6 +223,33 @@ func (s *Server) handleGlobalStats(w http.ResponseWriter, r *http.Request) {
 // --- Project handlers ---
 
 func (s *Server) handleListProjects(w http.ResponseWriter, r *http.Request) {
+	auth := apikeys.FromContext(r.Context())
+	if auth != nil && !auth.IsAdmin() {
+		projects, err := s.visibleProjects(auth, r.URL.Query().Get("search"))
+		if err != nil {
+			internalError(w, r, err)
+			return
+		}
+		if r.URL.Query().Get("limit") != "" {
+			limit, offset := clampPagination(queryInt(r, "limit", 30), queryInt(r, "offset", 0))
+			total := len(projects)
+			end := offset + limit
+			if offset > total {
+				offset = total
+			}
+			if end > total {
+				end = total
+			}
+			writeJSON(w, map[string]any{
+				"projects": projects[offset:end],
+				"total":    total,
+			})
+			return
+		}
+		writeJSON(w, projects)
+		return
+	}
+
 	// Paginated mode if ?limit= is present
 	if r.URL.Query().Get("limit") != "" {
 		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
@@ -249,6 +278,29 @@ func (s *Server) handleListProjects(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, projects)
+}
+
+func (s *Server) visibleProjects(auth *apikeys.AuthInfo, search string) ([]apikeys.Project, error) {
+	allowed := map[string]struct{}{}
+	for _, id := range auth.AllowedProjectIDs() {
+		allowed[id] = struct{}{}
+	}
+	search = strings.ToLower(strings.TrimSpace(search))
+	all, err := s.keyStore.ListProjects()
+	if err != nil {
+		return nil, err
+	}
+	projects := make([]apikeys.Project, 0, len(allowed))
+	for _, project := range all {
+		if _, ok := allowed[project.ID]; !ok {
+			continue
+		}
+		if search != "" && !strings.Contains(strings.ToLower(project.Name), search) {
+			continue
+		}
+		projects = append(projects, project)
+	}
+	return projects, nil
 }
 
 func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -1,0 +1,277 @@
+package server
+
+import (
+	"crypto/subtle"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/SEObserver/crawlobserver/internal/apikeys"
+)
+
+const authSessionTTL = 7 * 24 * time.Hour
+
+func (s *Server) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
+	if s.keyStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "local users are not available")
+		return
+	}
+
+	var req struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	user, err := s.keyStore.AuthenticateUser(req.Username, req.Password)
+	if err != nil {
+		user, err = s.authenticateConfigAdmin(req.Username, req.Password)
+	}
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "invalid username or password")
+		return
+	}
+
+	token, session, err := s.keyStore.CreateUserSession(user.ID, authSessionTTL)
+	if err != nil {
+		internalError(w, r, err)
+		return
+	}
+	setAuthCookie(w, token, session.ExpiresAt)
+	writeJSON(w, authUserPayload(user, "session"))
+}
+
+func (s *Server) authenticateConfigAdmin(username, password string) (*apikeys.User, error) {
+	if s.cfg.Server.Username == "" || s.cfg.Server.Password == "" {
+		return nil, sql.ErrNoRows
+	}
+	if subtle.ConstantTimeCompare([]byte(username), []byte(s.cfg.Server.Username)) != 1 ||
+		subtle.ConstantTimeCompare([]byte(password), []byte(s.cfg.Server.Password)) != 1 {
+		return nil, sql.ErrNoRows
+	}
+
+	user, err := s.keyStore.GetUserByUsername(username)
+	if err == nil {
+		if user.Role != apikeys.RoleAdmin || !user.Active {
+			active := true
+			pass := password
+			return s.keyStore.UpdateUser(user.ID, username, apikeys.RoleAdmin, active, &pass, nil)
+		}
+		return user, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+	return s.keyStore.CreateUser(username, password, apikeys.RoleAdmin, nil)
+}
+
+func (s *Server) handleAuthLogout(w http.ResponseWriter, r *http.Request) {
+	if s.keyStore != nil {
+		if cookie, err := r.Cookie(apikeys.SessionCookieName); err == nil {
+			_ = s.keyStore.DeleteUserSession(cookie.Value)
+		}
+	}
+	clearAuthCookie(w)
+	writeJSON(w, map[string]string{"status": "logged_out"})
+}
+
+func (s *Server) handleAuthMe(w http.ResponseWriter, r *http.Request) {
+	auth := apikeys.FromContext(r.Context())
+	if auth == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	if auth.Method == "session" && s.keyStore != nil && auth.UserID != "" {
+		user, err := s.keyStore.GetUser(auth.UserID)
+		if err == nil {
+			writeJSON(w, authUserPayload(user, auth.Method))
+			return
+		}
+	}
+	role := apikeys.RoleAdmin
+	projectIDs := []string{}
+	if !auth.IsAdmin() {
+		role = apikeys.RoleViewer
+		projectIDs = auth.AllowedProjectIDs()
+	}
+	writeJSON(w, map[string]interface{}{
+		"method":      auth.Method,
+		"username":    auth.Username,
+		"role":        role,
+		"project_ids": projectIDs,
+	})
+}
+
+func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
+	if !requireAdminAccess(w, r) {
+		return
+	}
+	if s.keyStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "local users are not available")
+		return
+	}
+	users, err := s.keyStore.ListUsers()
+	if err != nil {
+		internalError(w, r, err)
+		return
+	}
+	writeJSON(w, users)
+}
+
+func (s *Server) handleCreateUser(w http.ResponseWriter, r *http.Request) {
+	if !requireAdminAccess(w, r) {
+		return
+	}
+	if s.keyStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "local users are not available")
+		return
+	}
+	var req struct {
+		Username   string   `json:"username"`
+		Password   string   `json:"password"`
+		Role       string   `json:"role"`
+		ProjectIDs []string `json:"project_ids"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Role == "" {
+		req.Role = apikeys.RoleViewer
+	}
+	user, err := s.keyStore.CreateUser(req.Username, req.Password, req.Role, req.ProjectIDs)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	writeJSON(w, user)
+}
+
+func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
+	if !requireAdminAccess(w, r) {
+		return
+	}
+	if s.keyStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "local users are not available")
+		return
+	}
+	var req struct {
+		Username   string   `json:"username"`
+		Password   string   `json:"password"`
+		Role       string   `json:"role"`
+		Active     *bool    `json:"active"`
+		ProjectIDs []string `json:"project_ids"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	existing, err := s.keyStore.GetUser(r.PathValue("id"))
+	if err != nil {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	if req.Username == "" {
+		req.Username = existing.Username
+	}
+	if req.Role == "" {
+		req.Role = existing.Role
+	}
+	active := existing.Active
+	if req.Active != nil {
+		active = *req.Active
+	}
+	if existing.Role == apikeys.RoleAdmin && req.Role != apikeys.RoleAdmin {
+		admins, err := s.keyStore.CountUsersByRole(apikeys.RoleAdmin)
+		if err != nil {
+			internalError(w, r, err)
+			return
+		}
+		if admins <= 1 {
+			writeError(w, http.StatusBadRequest, "cannot change the role of the last administrator")
+			return
+		}
+	}
+	var password *string
+	if req.Password != "" {
+		password = &req.Password
+	}
+	user, err := s.keyStore.UpdateUser(existing.ID, req.Username, req.Role, active, password, req.ProjectIDs)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, user)
+}
+
+func (s *Server) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
+	if !requireAdminAccess(w, r) {
+		return
+	}
+	if s.keyStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "local users are not available")
+		return
+	}
+	user, err := s.keyStore.GetUser(r.PathValue("id"))
+	if err != nil {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	if user.Role == apikeys.RoleAdmin {
+		admins, err := s.keyStore.CountUsersByRole(apikeys.RoleAdmin)
+		if err != nil {
+			internalError(w, r, err)
+			return
+		}
+		if admins <= 1 {
+			writeError(w, http.StatusBadRequest, "cannot delete the last administrator")
+			return
+		}
+	}
+	if err := s.keyStore.DeleteUser(r.PathValue("id")); err != nil {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	writeJSON(w, map[string]string{"status": "deleted"})
+}
+
+func authUserPayload(user *apikeys.User, method string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":          user.ID,
+		"method":      method,
+		"username":    user.Username,
+		"role":        user.Role,
+		"project_ids": user.ProjectIDs,
+		"active":      user.Active,
+	}
+}
+
+func setAuthCookie(w http.ResponseWriter, token string, expires time.Time) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     apikeys.SessionCookieName,
+		Value:    token,
+		Path:     "/",
+		Expires:  expires,
+		MaxAge:   int(time.Until(expires).Seconds()),
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func clearAuthCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     apikeys.SessionCookieName,
+		Value:    "",
+		Path:     "/",
+		Expires:  time.Unix(0, 0),
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}

--- a/internal/server/handlers_providers.go
+++ b/internal/server/handlers_providers.go
@@ -17,6 +17,9 @@ import (
 
 func (s *Server) handleListProviderConnections(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	conns, err := s.keyStore.ListProviderConnections(projectID)
 	if err != nil {
 		internalError(w, r, err)
@@ -26,7 +29,13 @@ func (s *Server) handleListProviderConnections(w http.ResponseWriter, r *http.Re
 }
 
 func (s *Server) handleProviderConnect(w http.ResponseWriter, r *http.Request) {
+	if !requireFullAccess(w, r) {
+		return
+	}
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	provider := r.PathValue("provider")
 
 	var body struct {
@@ -108,7 +117,13 @@ func (s *Server) handleProviderConnect(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleProviderDisconnect(w http.ResponseWriter, r *http.Request) {
+	if !requireFullAccess(w, r) {
+		return
+	}
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	provider := r.PathValue("provider")
 	s.keyStore.DeleteProviderConnection(projectID, provider)
 	s.store.DeleteProviderData(r.Context(), projectID, provider)
@@ -117,6 +132,9 @@ func (s *Server) handleProviderDisconnect(w http.ResponseWriter, r *http.Request
 
 func (s *Server) handleProviderStatus(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	provider := r.PathValue("provider")
 
 	conn, err := s.keyStore.GetProviderConnection(projectID, provider)
@@ -153,7 +171,13 @@ func (s *Server) providerFetchKey(projectID, provider string) string {
 }
 
 func (s *Server) handleProviderFetch(w http.ResponseWriter, r *http.Request) {
+	if !requireFullAccess(w, r) {
+		return
+	}
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	provider := r.PathValue("provider")
 
 	var body struct {
@@ -437,10 +461,10 @@ func (s *Server) runProviderFetch(ctx context.Context, cancel context.CancelFunc
 				dataRows := make([]storage.ProviderDataRow, len(pages))
 				for i, p := range pages {
 					strData := map[string]string{
-						"title":              p.Title,
-						"language":           p.Language,
-						"last_crawl_result":  p.LastCrawlResult,
-						"last_crawl_date":    p.LastCrawlDate,
+						"title":             p.Title,
+						"language":          p.Language,
+						"last_crawl_result": p.LastCrawlResult,
+						"last_crawl_date":   p.LastCrawlDate,
 					}
 					numData := map[string]float64{
 						"out_links": float64(p.OutLinks),
@@ -513,7 +537,13 @@ func parseDate(s string) time.Time {
 }
 
 func (s *Server) handleProviderStopFetch(w http.ResponseWriter, r *http.Request) {
+	if !requireFullAccess(w, r) {
+		return
+	}
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	provider := r.PathValue("provider")
 	key := s.providerFetchKey(projectID, provider)
 	s.providerFetchMu.Lock()
@@ -527,6 +557,9 @@ func (s *Server) handleProviderStopFetch(w http.ResponseWriter, r *http.Request)
 
 func (s *Server) handleProviderMetrics(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	provider := r.PathValue("provider")
 	metrics, err := s.store.ProviderDomainMetrics(r.Context(), projectID, provider)
 	if err != nil {
@@ -538,6 +571,9 @@ func (s *Server) handleProviderMetrics(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleProviderBacklinks(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	provider := r.PathValue("provider")
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
@@ -561,6 +597,9 @@ func (s *Server) handleBacklinksTop(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "project_id is required")
 		return
 	}
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
 	if limit <= 0 {
@@ -579,6 +618,9 @@ func (s *Server) handleBacklinksTop(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleProviderRefDomains(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	provider := r.PathValue("provider")
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
@@ -596,6 +638,9 @@ func (s *Server) handleProviderRefDomains(w http.ResponseWriter, r *http.Request
 
 func (s *Server) handleProviderRankings(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	provider := r.PathValue("provider")
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
@@ -613,6 +658,9 @@ func (s *Server) handleProviderRankings(w http.ResponseWriter, r *http.Request) 
 
 func (s *Server) handleProviderVisibility(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	provider := r.PathValue("provider")
 	rows, err := s.store.ProviderVisibilityHistory(r.Context(), projectID, provider)
 	if err != nil {
@@ -624,6 +672,9 @@ func (s *Server) handleProviderVisibility(w http.ResponseWriter, r *http.Request
 
 func (s *Server) handleProviderTopPages(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	provider := r.PathValue("provider")
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
@@ -641,6 +692,9 @@ func (s *Server) handleProviderTopPages(w http.ResponseWriter, r *http.Request) 
 
 func (s *Server) handleProviderAPICalls(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	provider := r.PathValue("provider")
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
 	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
@@ -658,6 +712,9 @@ func (s *Server) handleProviderAPICalls(w http.ResponseWriter, r *http.Request) 
 
 func (s *Server) handleProviderData(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
+	if !requireProjectAccess(w, r, projectID) {
+		return
+	}
 	provider := r.PathValue("provider")
 	dataType := r.PathValue("dataType")
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
@@ -684,6 +741,9 @@ func (s *Server) handleSessionAuthority(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if !s.requireSessionAccess(w, r, sessionID) {
+		return
+	}
+	if !requireProjectAccess(w, r, projectID) {
 		return
 	}
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))

--- a/internal/server/handlers_sessions.go
+++ b/internal/server/handlers_sessions.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -26,17 +27,17 @@ import (
 )
 
 func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
+	auth := apikeys.FromContext(r.Context())
+	if auth != nil && !auth.IsAdmin() {
+		s.handleScopedSessions(w, r, auth)
+		return
+	}
+
 	// Paginated mode if ?limit= is present
 	if r.URL.Query().Get("limit") != "" {
 		limit, offset := clampPagination(queryInt(r, "limit", 30), queryInt(r, "offset", 0))
 		projectID := r.URL.Query().Get("project_id")
 		search := r.URL.Query().Get("search")
-
-		// If project API key, force project filter
-		auth := apikeys.FromContext(r.Context())
-		if auth != nil && auth.ProjectID != nil {
-			projectID = *auth.ProjectID
-		}
 
 		sessions, total, err := s.store.ListSessionsPaginated(r.Context(), limit, offset, projectID, search)
 		if err != nil {
@@ -77,13 +78,7 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 	var sessions []storage.CrawlSession
 	var err error
 
-	// If project API key, filter by project
-	auth := apikeys.FromContext(r.Context())
-	if auth != nil && auth.ProjectID != nil {
-		sessions, err = s.store.ListSessions(r.Context(), *auth.ProjectID)
-	} else {
-		sessions, err = s.store.ListSessions(r.Context())
-	}
+	sessions, err = s.store.ListSessions(r.Context())
 	if err != nil {
 		internalError(w, r, err)
 		return
@@ -112,6 +107,85 @@ func (s *Server) handleSessions(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	writeJSON(w, resp)
+}
+
+func (s *Server) handleScopedSessions(w http.ResponseWriter, r *http.Request, auth *apikeys.AuthInfo) {
+	allowed := auth.AllowedProjectIDs()
+	search := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("search")))
+	var sessions []storage.CrawlSession
+	for _, projectID := range allowed {
+		projectSessions, err := s.store.ListSessions(r.Context(), projectID)
+		if err != nil {
+			internalError(w, r, err)
+			return
+		}
+		for _, sess := range projectSessions {
+			if search != "" && !sessionMatchesSearch(sess, search) {
+				continue
+			}
+			sessions = append(sessions, sess)
+		}
+	}
+	sort.SliceStable(sessions, func(i, j int) bool {
+		return sessions[i].StartedAt.After(sessions[j].StartedAt)
+	})
+
+	resp := s.sessionListPayload(sessions)
+	if r.URL.Query().Get("limit") != "" {
+		limit, offset := clampPagination(queryInt(r, "limit", 30), queryInt(r, "offset", 0))
+		total := len(resp)
+		end := offset + limit
+		if offset > total {
+			offset = total
+		}
+		if end > total {
+			end = total
+		}
+		writeJSON(w, map[string]interface{}{
+			"sessions": resp[offset:end],
+			"total":    total,
+		})
+		return
+	}
+	writeJSON(w, resp)
+}
+
+func sessionMatchesSearch(sess storage.CrawlSession, search string) bool {
+	for _, seed := range sess.SeedURLs {
+		if strings.Contains(strings.ToLower(seed), search) {
+			return true
+		}
+	}
+	return strings.Contains(strings.ToLower(sess.ID), search) ||
+		strings.Contains(strings.ToLower(sess.Label), search)
+}
+
+func (s *Server) sessionListPayload(sessions []storage.CrawlSession) []map[string]interface{} {
+	var resp []map[string]interface{}
+	for _, sess := range sessions {
+		pagesCrawled := sess.PagesCrawled
+		if pages, _, running := s.manager.Progress(sess.ID); running {
+			pagesCrawled = uint64(pages)
+		}
+		resp = append(resp, map[string]interface{}{
+			"ID":           sess.ID,
+			"StartedAt":    sess.StartedAt,
+			"FinishedAt":   sess.FinishedAt,
+			"Status":       sess.Status,
+			"SeedURLs":     sess.SeedURLs,
+			"Config":       config.RedactSensitiveConfigJSON(sess.Config),
+			"PagesCrawled": pagesCrawled,
+			"UserAgent":    sess.UserAgent,
+			"ProjectID":    sess.ProjectID,
+			"Label":        sess.Label,
+			"is_running":   s.manager.IsRunning(sess.ID),
+			"is_queued":    s.manager.IsQueued(sess.ID),
+		})
+	}
+	if resp == nil {
+		resp = []map[string]interface{}{}
+	}
+	return resp
 }
 
 func (s *Server) handlePages(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -202,8 +202,11 @@ func (s *Server) buildHandler() (http.Handler, error) {
 	mux.HandleFunc("GET /api/compare/stats", s.handleCompareStats)
 	mux.HandleFunc("GET /api/compare/pages", s.handleComparePages)
 	mux.HandleFunc("GET /api/compare/links", s.handleCompareLinks)
+	mux.HandleFunc("GET /api/auth/me", s.handleAuthMe)
 
 	// API routes - write
+	mux.HandleFunc("POST /api/auth/login", s.handleAuthLogin)
+	mux.HandleFunc("POST /api/auth/logout", s.handleAuthLogout)
 	mux.HandleFunc("PUT /api/theme", s.handleUpdateTheme)
 	mux.HandleFunc("POST /api/check-ip", s.handleCheckIP)
 	mux.HandleFunc("POST /api/crawl", s.handleStartCrawl)
@@ -254,6 +257,10 @@ func (s *Server) buildHandler() (http.Handler, error) {
 	mux.HandleFunc("GET /api/api-keys", s.handleListAPIKeys)
 	mux.HandleFunc("POST /api/api-keys", s.handleCreateAPIKey)
 	mux.HandleFunc("DELETE /api/api-keys/{id}", s.handleDeleteAPIKey)
+	mux.HandleFunc("GET /api/users", s.handleListUsers)
+	mux.HandleFunc("POST /api/users", s.handleCreateUser)
+	mux.HandleFunc("PUT /api/users/{id}", s.handleUpdateUser)
+	mux.HandleFunc("DELETE /api/users/{id}", s.handleDeleteUser)
 
 	// GSC (Google Search Console) routes
 	mux.HandleFunc("GET /api/gsc/authorize", s.handleGSCAuthorize)
@@ -364,10 +371,10 @@ func (s *Server) buildHandler() (http.Handler, error) {
 	var handler http.Handler = mux
 	switch {
 	case s.keyStore != nil && s.cfg.Server.Username != "" && s.cfg.Server.Password != "":
-		handler = apikeys.Authenticate(s.keyStore, s.cfg.Server.Username, s.cfg.Server.Password)(mux)
+		handler = allowPublicPaths(apikeys.Authenticate(s.keyStore, s.cfg.Server.Username, s.cfg.Server.Password)(mux), mux)
 		applog.Infof("server", "Authentication enabled (API keys + basic auth) — user: %s, password in config.yaml", s.cfg.Server.Username)
 	case s.cfg.Server.Username != "" && s.cfg.Server.Password != "":
-		handler = basicAuth(mux, s.cfg.Server.Username, s.cfg.Server.Password)
+		handler = allowPublicPaths(basicAuth(mux, s.cfg.Server.Username, s.cfg.Server.Password), mux)
 		applog.Infof("server", "Basic authentication enabled — user: %s, password in config.yaml", s.cfg.Server.Username)
 	default:
 		if s.cfg.Server.Host == "0.0.0.0" || (s.cfg.Server.Host != "127.0.0.1" && s.cfg.Server.Host != "localhost") {
@@ -385,6 +392,35 @@ func (s *Server) buildHandler() (http.Handler, error) {
 	handler = s.requireReady(handler)
 	handler = s.securityHeaders(handler)
 	return handler, nil
+}
+
+func allowPublicPaths(authenticated http.Handler, mux http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isPublicPath(r) {
+			mux.ServeHTTP(w, r)
+			return
+		}
+		authenticated.ServeHTTP(w, r)
+	})
+}
+
+func isPublicPath(r *http.Request) bool {
+	if r.Method == http.MethodGet && r.URL.Path == "/api/health" {
+		return true
+	}
+	if r.Method == http.MethodGet && r.URL.Path == "/api/theme" {
+		return true
+	}
+	if r.Method == http.MethodGet && r.URL.Path == "/api/setup/status" {
+		return true
+	}
+	if r.URL.Path == "/api/auth/login" && r.Method == http.MethodPost {
+		return true
+	}
+	if strings.HasPrefix(r.URL.Path, "/api/") {
+		return false
+	}
+	return r.Method == http.MethodGet || r.Method == http.MethodHead
 }
 
 const banner = `
@@ -480,7 +516,6 @@ func (s *Server) Start() error {
 
 	return s.server.ListenAndServe()
 }
-
 
 // Stop gracefully shuts down the server.
 func (s *Server) Stop(ctx context.Context) error {
@@ -765,20 +800,38 @@ func (s *Server) handleUpdateSessionRecording(w http.ResponseWriter, r *http.Req
 
 // --- Auth helpers ---
 
-// requireFullAccess returns 403 if the caller is a project-scoped key.
+// requireFullAccess returns 403 if the caller has read-only scoped credentials.
 func requireFullAccess(w http.ResponseWriter, r *http.Request) bool {
 	auth := apikeys.FromContext(r.Context())
 	if auth != nil && auth.IsReadOnly() {
-		writeError(w, http.StatusForbidden, "project API keys do not have access to this endpoint")
+		writeError(w, http.StatusForbidden, "read-only credentials do not have access to this endpoint")
 		return false
 	}
 	return true
 }
 
+func requireAdminAccess(w http.ResponseWriter, r *http.Request) bool {
+	auth := apikeys.FromContext(r.Context())
+	if auth != nil && !auth.IsAdmin() {
+		writeError(w, http.StatusForbidden, "admin access required")
+		return false
+	}
+	return true
+}
+
+func requireProjectAccess(w http.ResponseWriter, r *http.Request, projectID string) bool {
+	auth := apikeys.FromContext(r.Context())
+	if auth == nil || auth.HasProjectAccess(projectID) {
+		return true
+	}
+	writeError(w, http.StatusForbidden, "project not accessible")
+	return false
+}
+
 // requireSessionAccess checks that a project key can access the given session.
 func (s *Server) requireSessionAccess(w http.ResponseWriter, r *http.Request, sessionID string) bool {
 	auth := apikeys.FromContext(r.Context())
-	if auth == nil || auth.ProjectID == nil {
+	if auth == nil || auth.IsAdmin() {
 		return true
 	}
 	sess, err := s.store.GetSession(r.Context(), sessionID)
@@ -786,7 +839,7 @@ func (s *Server) requireSessionAccess(w http.ResponseWriter, r *http.Request, se
 		writeError(w, http.StatusNotFound, "session not found")
 		return false
 	}
-	if sess.ProjectID == nil || *sess.ProjectID != *auth.ProjectID {
+	if sess.ProjectID == nil || !auth.HasProjectAccess(*sess.ProjectID) {
 		writeError(w, http.StatusForbidden, "session not accessible with this API key")
 		return false
 	}
@@ -799,7 +852,9 @@ func basicAuth(next http.Handler, username, password string) http.Handler {
 		if !ok ||
 			subtle.ConstantTimeCompare([]byte(user), []byte(username)) != 1 ||
 			subtle.ConstantTimeCompare([]byte(pass), []byte(password)) != 1 {
-			w.Header().Set("WWW-Authenticate", `Basic realm="CrawlObserver"`)
+			if !strings.HasPrefix(r.URL.Path, "/api/") {
+				w.Header().Set("WWW-Authenticate", `Basic realm="CrawlObserver"`)
+			}
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -749,6 +749,22 @@ func TestAuth_NoCredentials(t *testing.T) {
 	}
 }
 
+func TestAuth_HealthAllowsNoCredentials(t *testing.T) {
+	_, handler, _ := newTestServer(t)
+	req := httptest.NewRequest("GET", "/api/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	var resp map[string]string
+	decodeJSON(t, rec, &resp)
+	if resp["status"] != "ok" {
+		t.Errorf("expected status ok, got %q", resp["status"])
+	}
+}
+
 func TestAuth_ValidBasicAuth(t *testing.T) {
 	_, handler, _ := newTestServer(t)
 	req := httptest.NewRequest("GET", "/api/sessions", nil)
@@ -825,11 +841,8 @@ func TestAuth_SecurityHeaders(t *testing.T) {
 }
 
 func TestAuth_HealthNoAuth(t *testing.T) {
-	// Health endpoint is behind the same auth middleware in the current code,
-	// but we test that it responds correctly when authorized.
 	_, handler, _ := newTestServer(t)
 	req := httptest.NewRequest("GET", "/api/health", nil)
-	req.SetBasicAuth("admin", "secret")
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -841,6 +854,33 @@ func TestAuth_HealthNoAuth(t *testing.T) {
 	decodeJSON(t, rec, &body)
 	if body["status"] != "ok" {
 		t.Errorf("expected status ok, got %q", body["status"])
+	}
+}
+
+func TestAuth_PublicBootstrapEndpointsNoAuth(t *testing.T) {
+	_, handler, _ := newTestServer(t)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "theme", path: "/api/theme"},
+		{name: "setup status", path: "/api/setup/status"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.path, nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+			}
+			if rec.Header().Get("WWW-Authenticate") != "" {
+				t.Fatalf("did not expect WWW-Authenticate header on public bootstrap endpoint")
+			}
+		})
 	}
 }
 
@@ -1526,6 +1566,154 @@ func TestAPIKeys_ProjectKeyReadOnly(t *testing.T) {
 
 	if rec.Code != http.StatusForbidden {
 		t.Errorf("project key list api-keys: expected 403, got %d", rec.Code)
+	}
+}
+
+func TestProjects_ProjectKeyListIsScoped(t *testing.T) {
+	_, handler, ks := newTestServer(t)
+
+	allowed, _ := ks.CreateProject("allowed-project")
+	_, _ = ks.CreateProject("hidden-project")
+	key, _ := ks.CreateAPIKey("project-client", "project", &allowed.ID)
+
+	req := httptest.NewRequest("GET", "/api/projects", nil)
+	req.Header.Set("X-API-Key", key.FullKey)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var projects []apikeys.Project
+	decodeJSON(t, rec, &projects)
+	if len(projects) != 1 || projects[0].ID != allowed.ID {
+		t.Fatalf("expected only allowed project %q, got %#v", allowed.ID, projects)
+	}
+}
+
+func TestUsers_ViewerSessionIsProjectScoped(t *testing.T) {
+	srv, handler, ks := newTestServer(t)
+
+	allowed, _ := ks.CreateProject("viewer-project")
+	hidden, _ := ks.CreateProject("hidden-project")
+	user, err := ks.CreateUser("client", "password123", apikeys.RoleViewer, []string{allowed.ID})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	token, _, err := ks.CreateUserSession(user.ID, time.Hour)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	ms := srv.store.(*mockStore)
+	ms.sessions = []storage.CrawlSession{
+		{ID: "allowed-session", Status: "completed", ProjectID: &allowed.ID},
+		{ID: "hidden-session", Status: "completed", ProjectID: &hidden.ID},
+	}
+
+	req := httptest.NewRequest("GET", "/api/projects", nil)
+	req.AddCookie(&http.Cookie{Name: apikeys.SessionCookieName, Value: token})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list projects: expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var projects []apikeys.Project
+	decodeJSON(t, rec, &projects)
+	if len(projects) != 1 || projects[0].ID != allowed.ID {
+		t.Fatalf("expected only allowed project %q, got %#v", allowed.ID, projects)
+	}
+
+	req = httptest.NewRequest("GET", "/api/projects?limit=30&offset=0", nil)
+	req.AddCookie(&http.Cookie{Name: apikeys.SessionCookieName, Value: token})
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list paginated projects: expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var paged struct {
+		Projects []apikeys.Project `json:"projects"`
+		Total    int               `json:"total"`
+	}
+	decodeJSON(t, rec, &paged)
+	if paged.Total != 1 || len(paged.Projects) != 1 || paged.Projects[0].ID != allowed.ID {
+		t.Fatalf("expected paginated response to contain only allowed project %q, got %#v", allowed.ID, paged)
+	}
+
+	req = httptest.NewRequest("GET", "/api/sessions", nil)
+	req.AddCookie(&http.Cookie{Name: apikeys.SessionCookieName, Value: token})
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list sessions: expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var sessions []map[string]interface{}
+	decodeJSON(t, rec, &sessions)
+	if len(sessions) != 1 || sessions[0]["ID"] != "allowed-session" {
+		t.Fatalf("expected only allowed session, got %#v", sessions)
+	}
+
+	req = httptest.NewRequest("GET", "/api/users", nil)
+	req.AddCookie(&http.Cookie{Name: apikeys.SessionCookieName, Value: token})
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("viewer list users: expected 403, got %d", rec.Code)
+	}
+}
+
+func TestUsers_LastAdminCannotChangeRoleOrDelete(t *testing.T) {
+	_, handler, ks := newTestServer(t)
+
+	owner, err := ks.CreateUser("owner", "password123", apikeys.RoleAdmin, nil)
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+
+	body := jsonBody(t, map[string]interface{}{
+		"username":    owner.Username,
+		"role":        apikeys.RoleViewer,
+		"active":      true,
+		"project_ids": []string{},
+	})
+	req := authRequest(httptest.NewRequest("PUT", "/api/users/"+owner.ID, body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("change last admin role: expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	req = authRequest(httptest.NewRequest("DELETE", "/api/users/"+owner.ID, nil))
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("delete last admin: expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	if _, err := ks.CreateUser("backup-admin", "password123", apikeys.RoleAdmin, nil); err != nil {
+		t.Fatalf("create backup admin: %v", err)
+	}
+
+	body = jsonBody(t, map[string]interface{}{
+		"username":    owner.Username,
+		"role":        apikeys.RoleViewer,
+		"active":      true,
+		"project_ids": []string{},
+	})
+	req = authRequest(httptest.NewRequest("PUT", "/api/users/"+owner.ID, body))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("change admin role with backup admin: expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	updated, err := ks.GetUser(owner.ID)
+	if err != nil {
+		t.Fatalf("get updated owner: %v", err)
+	}
+	if updated.Role != apikeys.RoleViewer {
+		t.Fatalf("expected owner to become viewer, got %q", updated.Role)
 	}
 }
 
@@ -2837,7 +3025,7 @@ func TestSSEQueuedSession(t *testing.T) {
 
 	// Run handler in a goroutine since SSE blocks; cancel the request context
 	// after a short window so we collect at least the first data line.
-	ctx, cancel := context.WithTimeout(req.Context(), 500*time.Millisecond)
+	ctx, cancel := context.WithTimeout(req.Context(), 1200*time.Millisecond)
 	defer cancel()
 	req = req.WithContext(ctx)
 
@@ -5006,6 +5194,24 @@ func TestBasicAuth_NoCredentials(t *testing.T) {
 	}
 }
 
+func TestBasicAuth_APINoCredentialsNoChallenge(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := basicAuth(inner, "admin", "password")
+
+	req := httptest.NewRequest("GET", "/api/projects", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rec.Code)
+	}
+	if rec.Header().Get("WWW-Authenticate") != "" {
+		t.Error("did not expect WWW-Authenticate header for API request")
+	}
+}
+
 func TestBasicAuth_WrongUsername(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -6063,8 +6269,8 @@ func TestSecurityHeaders(t *testing.T) {
 
 	expectedHeaders := map[string]string{
 		"X-Content-Type-Options": "nosniff",
-		"X-Frame-Options":       "DENY",
-		"X-XSS-Protection":      "1; mode=block",
+		"X-Frame-Options":        "DENY",
+		"X-XSS-Protection":       "1; mode=block",
 		"Referrer-Policy":        "strict-origin-when-cross-origin",
 	}
 	for k, v := range expectedHeaders {
@@ -7210,8 +7416,8 @@ func TestRestoreBackup_WithStopStartClickHouse(t *testing.T) {
 	srv, handler, _ := newTestServer(t)
 	tmpDir := t.TempDir()
 	srv.BackupOpts = &backup.BackupOptions{
-		DataDir:    t.TempDir(),
-		BackupDir:  tmpDir,
+		DataDir:   t.TempDir(),
+		BackupDir: tmpDir,
 	}
 
 	// Create a fake backup file
@@ -8627,16 +8833,24 @@ func TestBuildHandler_BasicAuthOnly(t *testing.T) {
 		t.Fatalf("buildHandler error: %v", err)
 	}
 
-	// Should require basic auth
+	// Health remains public for monitors even when auth is enabled.
 	req := httptest.NewRequest("GET", "/api/health", nil)
 	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected public health 200, got %d", rec.Code)
+	}
+
+	// Other API endpoints should still require basic auth.
+	req = httptest.NewRequest("GET", "/api/sessions", nil)
+	rec = httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401 without auth, got %d", rec.Code)
 	}
 
 	// Should work with correct basic auth
-	req = httptest.NewRequest("GET", "/api/health", nil)
+	req = httptest.NewRequest("GET", "/api/sessions", nil)
 	req.SetBasicAuth("user", "pass")
 	rec = httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)


### PR DESCRIPTION
## Summary

- adds cookie/session login endpoints and a dedicated login page without browser basic-auth prompts for API routes
- adds user management under Settings, including project-scoped users and admin safeguards
- extends API key auth to support multiple allowed project IDs and enforces project/session/provider visibility for scoped credentials
- updates sidebar/project/UI flows to respect the logged-in user role and visible projects

## Validation

- npm run --prefix frontend build
- git diff --check
- Go tests were not run locally because `go` is not installed in PATH.
