### PR TITLE
Preserve crawl scope across seed redirects

### DIFF
--- a/internal/crawler/engine.go
+++ b/internal/crawler/engine.go
@@ -48,6 +48,7 @@ type Engine struct {
 	allowedHosts    map[string]bool
 	allowedDomains  map[string]bool
 	allowedPrefixes []string
+	scopeMu         sync.RWMutex
 
 	retryQueue       *RetryQueue
 	hostHealth       *HostHealth
@@ -187,34 +188,75 @@ func (e *Engine) MarkSeen(url string) {
 
 // buildScope extracts allowed hostnames/domains from the session's original seed URLs.
 func (e *Engine) buildScope() {
+	e.scopeMu.Lock()
+	defer e.scopeMu.Unlock()
+
 	e.allowedHosts = make(map[string]bool)
 	e.allowedDomains = make(map[string]bool)
 	e.allowedPrefixes = nil
 
 	seedURLs := e.session.SeedURLs
 	for _, seed := range seedURLs {
-		u, err := url.Parse(seed)
-		if err != nil {
-			continue
-		}
-		host := strings.ToLower(u.Hostname())
-		e.allowedHosts[host] = true
-		domain, err := publicsuffix.EffectiveTLDPlusOne(host)
-		if err == nil {
-			e.allowedDomains[strings.ToLower(domain)] = true
-		}
-		if e.cfg.Crawler.CrawlScope == "subdirectory" {
-			dir := path.Dir(u.Path)
-			if strings.HasSuffix(u.Path, "/") {
-				dir = u.Path
-			}
-			if !strings.HasSuffix(dir, "/") {
-				dir += "/"
-			}
-			prefix := strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host) + dir
-			e.allowedPrefixes = append(e.allowedPrefixes, prefix)
-		}
+		e.addScopeURLLocked(seed)
 	}
+}
+
+func (e *Engine) registerFinalURLScope(result *fetcher.FetchResult) {
+	if result == nil || result.FinalURL == "" || result.FinalURL == result.URL {
+		return
+	}
+	if !e.isInScope(result.URL) {
+		return
+	}
+
+	e.scopeMu.Lock()
+	defer e.scopeMu.Unlock()
+	e.addScopeURLLocked(result.FinalURL)
+}
+
+func (e *Engine) addScopeURLLocked(rawURL string) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return
+	}
+	e.allowedHosts[host] = true
+	domain, err := publicsuffix.EffectiveTLDPlusOne(host)
+	if err == nil {
+		e.allowedDomains[strings.ToLower(domain)] = true
+	}
+	if e.cfg.Crawler.CrawlScope == "subdirectory" {
+		prefix := strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host) + subdirectoryScopeDir(u.Path)
+		for _, existing := range e.allowedPrefixes {
+			if existing == prefix {
+				return
+			}
+		}
+		e.allowedPrefixes = append(e.allowedPrefixes, prefix)
+	}
+}
+
+func subdirectoryScopeDir(p string) string {
+	if p == "" || p == "." {
+		return "/"
+	}
+	dir := path.Dir(p)
+	if strings.HasSuffix(p, "/") {
+		dir = p
+	}
+	if dir == "." {
+		dir = "/"
+	}
+	if !strings.HasPrefix(dir, "/") {
+		dir = "/" + dir
+	}
+	if !strings.HasSuffix(dir, "/") {
+		dir += "/"
+	}
+	return dir
 }
 
 // isInScope checks if a URL falls within the configured crawl scope.
@@ -224,6 +266,9 @@ func (e *Engine) isInScope(targetURL string) bool {
 		return false
 	}
 	host := strings.ToLower(u.Hostname())
+
+	e.scopeMu.RLock()
+	defer e.scopeMu.RUnlock()
 
 	switch e.cfg.Crawler.CrawlScope {
 	case "domain":
@@ -794,6 +839,9 @@ func (e *Engine) parseWorker(id int, in <-chan *fetcher.FetchResult) {
 		// Store the original redirect status code instead of the final 200,
 		// and skip content parsing (the body belongs to the final URL).
 		isRedirect := len(result.RedirectChain) > 0 && result.URL != result.FinalURL
+		if isRedirect {
+			e.registerFinalURLScope(result)
+		}
 
 		// Build page row
 		pageRow := storage.PageRow{

--- a/internal/crawler/engine_test.go
+++ b/internal/crawler/engine_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/SEObserver/crawlobserver/internal/config"
 	"github.com/SEObserver/crawlobserver/internal/extraction"
 	"github.com/SEObserver/crawlobserver/internal/fetcher"
-	"github.com/SEObserver/crawlobserver/internal/schema"
 	"github.com/SEObserver/crawlobserver/internal/frontier"
 	"github.com/SEObserver/crawlobserver/internal/normalizer"
 	"github.com/SEObserver/crawlobserver/internal/parser"
+	"github.com/SEObserver/crawlobserver/internal/schema"
 	"github.com/SEObserver/crawlobserver/internal/storage"
 )
 
@@ -440,6 +440,63 @@ func TestIsInScope_Subdirectory(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestRegisterFinalURLScope_HostRedirectAlias(t *testing.T) {
+	cfg := &config.Config{
+		Crawler: config.CrawlerConfig{
+			UserAgent:  "TestBot/1.0",
+			CrawlScope: "host",
+		},
+	}
+	engine := NewEngine(cfg, nil)
+	engine.session = NewSession([]string{"https://example.com/raid-recovery/"}, cfg)
+	engine.buildScope()
+
+	if engine.isInScope("https://www.example.com/raid-recovery/how-to-recover-data-from-raid-drives/") {
+		t.Fatal("www host should not be in scope before registering the final redirect URL")
+	}
+
+	engine.registerFinalURLScope(&fetcher.FetchResult{
+		URL:           "https://example.com/raid-recovery/",
+		FinalURL:      "https://www.example.com/raid-recovery/",
+		RedirectChain: []fetcher.RedirectHop{{URL: "https://example.com/raid-recovery/", StatusCode: 301}},
+	})
+
+	if !engine.isInScope("https://www.example.com/raid-recovery/how-to-recover-data-from-raid-drives/") {
+		t.Fatal("www host should be in scope after registering the final redirect URL")
+	}
+}
+
+func TestRegisterFinalURLScope_SubdirectoryRedirectAlias(t *testing.T) {
+	cfg := &config.Config{
+		Crawler: config.CrawlerConfig{
+			UserAgent:  "TestBot/1.0",
+			CrawlScope: "subdirectory",
+		},
+	}
+	engine := NewEngine(cfg, nil)
+	engine.session = NewSession([]string{"https://example.com/raid-recovery/"}, cfg)
+	engine.buildScope()
+
+	inDirectory := "https://www.example.com/raid-recovery/how-to-recover-data-from-raid-drives/"
+	outsideDirectory := "https://www.example.com/vmfs-recovery/"
+	if engine.isInScope(inDirectory) {
+		t.Fatal("www subdirectory URL should not be in scope before registering the final redirect URL")
+	}
+
+	engine.registerFinalURLScope(&fetcher.FetchResult{
+		URL:           "https://example.com/raid-recovery/",
+		FinalURL:      "https://www.example.com/raid-recovery/",
+		RedirectChain: []fetcher.RedirectHop{{URL: "https://example.com/raid-recovery/", StatusCode: 301}},
+	})
+
+	if !engine.isInScope(inDirectory) {
+		t.Fatal("www subdirectory URL should be in scope after registering the final redirect URL")
+	}
+	if engine.isInScope(outsideDirectory) {
+		t.Fatal("redirect alias must not broaden subdirectory scope outside the final URL directory")
+	}
 }
 
 type successInserter struct{}
@@ -2349,9 +2406,9 @@ func TestIsExcluded(t *testing.T) {
 		{"https://example.com/login?next=/dashboard", true},
 		{"https://example.com/cart/item-123", true},
 		{"https://example.com/products/widget", false},
-		{"https://example.com/register", false},     // no ?redirect_url=
+		{"https://example.com/register", false},      // no ?redirect_url=
 		{"https://example.com/login", false},         // no trailing ?
-		{"https://example.com/shopping-cart", false},  // not /cart/
+		{"https://example.com/shopping-cart", false}, // not /cart/
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- registers the final redirected URL as an allowed scope alias when an in-scope seed redirects to another host
- keeps Same Subdirectory scope constrained to the final URL directory instead of broadening to the whole host
- adds tests for host and subdirectory redirect aliases

## Validation

- git diff --check
- Go tests were not run locally because `go` is not installed in PATH.
