### PR TITLE
[codex] Chunk GSC analytics critical export

### DIFF
--- a/internal/storage/export_critical.go
+++ b/internal/storage/export_critical.go
@@ -81,12 +81,27 @@ func (s *Store) exportCriticalTable(ctx context.Context, dir, table, ts string) 
 
 	enc := json.NewEncoder(gw)
 
+	if table == "gsc_analytics" {
+		if err := s.exportGSCAnalyticsRows(ctx, enc); err != nil {
+			os.Remove(path)
+			return err
+		}
+		return nil
+	}
+
 	// Stream all rows without LIMIT/OFFSET (deterministic, no missed/duplicated rows).
 	// The driver handles streaming natively — rows are fetched in blocks.
-	query := fmt.Sprintf("SELECT * FROM %s", table)
-	rows, err := s.conn.Query(ctx, query)
-	if err != nil {
+	if err := s.exportCriticalTableQueryRows(ctx, enc, fmt.Sprintf("SELECT * FROM %s", table)); err != nil {
 		os.Remove(path)
+		return err
+	}
+
+	return nil
+}
+
+func (s *Store) exportCriticalTableQueryRows(ctx context.Context, enc *json.Encoder, query string, args ...interface{}) error {
+	rows, err := s.conn.Query(ctx, query, args...)
+	if err != nil {
 		return fmt.Errorf("querying: %w", err)
 	}
 	defer rows.Close()
@@ -101,7 +116,6 @@ func (s *Store) exportCriticalTable(ctx context.Context, dir, table, ts string) 
 			values[i] = new(interface{})
 		}
 		if err := rows.Scan(values...); err != nil {
-			os.Remove(path)
 			return fmt.Errorf("scanning row: %w", err)
 		}
 
@@ -111,16 +125,118 @@ func (s *Store) exportCriticalTable(ctx context.Context, dir, table, ts string) 
 			row[name] = *(values[i].(*interface{}))
 		}
 		if err := enc.Encode(row); err != nil {
-			os.Remove(path)
 			return fmt.Errorf("encoding row: %w", err)
 		}
 	}
 
 	if err := rows.Err(); err != nil {
-		os.Remove(path)
 		return fmt.Errorf("iterating rows: %w", err)
 	}
 
+	return nil
+}
+
+func (s *Store) exportGSCAnalyticsRows(ctx context.Context, enc *json.Encoder) error {
+	chunks, err := s.gscAnalyticsExportChunks(ctx)
+	if err != nil {
+		return err
+	}
+	for _, chunk := range chunks {
+		if err := s.exportGSCAnalyticsChunk(ctx, enc, chunk); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type gscAnalyticsExportChunk struct {
+	ProjectID string
+	StartDate time.Time
+	EndDate   time.Time
+}
+
+func (s *Store) gscAnalyticsExportChunks(ctx context.Context) ([]gscAnalyticsExportChunk, error) {
+	rows, err := s.conn.Query(ctx, `
+		SELECT project_id, min(date), max(date)
+		FROM gsc_analytics
+		GROUP BY project_id
+		ORDER BY project_id`)
+	if err != nil {
+		return nil, fmt.Errorf("querying gsc_analytics export ranges: %w", err)
+	}
+	defer rows.Close()
+
+	var chunks []gscAnalyticsExportChunk
+	for rows.Next() {
+		var projectID string
+		var minDate, maxDate time.Time
+		if err := rows.Scan(&projectID, &minDate, &maxDate); err != nil {
+			return nil, fmt.Errorf("scanning gsc_analytics export range: %w", err)
+		}
+		chunks = append(chunks, gscAnalyticsDailyChunks(projectID, minDate, maxDate)...)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return chunks, nil
+}
+
+func gscAnalyticsDailyChunks(projectID string, minDate, maxDate time.Time) []gscAnalyticsExportChunk {
+	start := dateOnly(minDate)
+	last := dateOnly(maxDate)
+	if projectID == "" || start.IsZero() || last.IsZero() || last.Before(start) {
+		return nil
+	}
+	chunks := make([]gscAnalyticsExportChunk, 0, int(last.Sub(start).Hours()/24)+1)
+	for day := start; !day.After(last); day = day.AddDate(0, 0, 1) {
+		chunks = append(chunks, gscAnalyticsExportChunk{
+			ProjectID: projectID,
+			StartDate: day,
+			EndDate:   day.AddDate(0, 0, 1),
+		})
+	}
+	return chunks
+}
+
+func dateOnly(t time.Time) time.Time {
+	if t.IsZero() {
+		return time.Time{}
+	}
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func (s *Store) exportGSCAnalyticsChunk(ctx context.Context, enc *json.Encoder, chunk gscAnalyticsExportChunk) error {
+	rows, err := s.conn.Query(ctx, `
+		SELECT project_id, date, query, page, country, device,
+			clicks, impressions, ctr, position, fetched_at
+		FROM gsc_analytics FINAL
+		WHERE project_id = ? AND date >= ? AND date < ?
+		ORDER BY date, query, page, country, device`,
+		chunk.ProjectID, chunk.StartDate, chunk.EndDate)
+	if err != nil {
+		return fmt.Errorf("querying gsc_analytics chunk project=%s date=%s: %w", chunk.ProjectID, chunk.StartDate.Format("2006-01-02"), err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var projectID, query, page, country, device string
+		var date, fetchedAt time.Time
+		var clicks, impressions uint32
+		var ctr, position float32
+		if err := rows.Scan(&projectID, &date, &query, &page, &country, &device, &clicks, &impressions, &ctr, &position, &fetchedAt); err != nil {
+			return fmt.Errorf("scanning gsc_analytics chunk project=%s date=%s: %w", chunk.ProjectID, chunk.StartDate.Format("2006-01-02"), err)
+		}
+		if err := enc.Encode(map[string]interface{}{
+			"project_id": projectID, "date": date, "query": query, "page": page,
+			"country": country, "device": device, "clicks": clicks,
+			"impressions": impressions, "ctr": ctr, "position": position, "fetched_at": fetchedAt,
+		}); err != nil {
+			return fmt.Errorf("encoding gsc_analytics chunk project=%s date=%s: %w", chunk.ProjectID, chunk.StartDate.Format("2006-01-02"), err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("reading gsc_analytics chunk project=%s date=%s: %w", chunk.ProjectID, chunk.StartDate.Format("2006-01-02"), err)
+	}
 	return nil
 }
 

--- a/internal/storage/export_critical_test.go
+++ b/internal/storage/export_critical_test.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGSCAnalyticsDailyChunks(t *testing.T) {
+	minDate := time.Date(2026, 6, 7, 15, 30, 0, 0, time.FixedZone("test", 3*60*60))
+	maxDate := time.Date(2026, 6, 9, 2, 0, 0, 0, time.UTC)
+
+	chunks := gscAnalyticsDailyChunks("project-1", minDate, maxDate)
+	if len(chunks) != 3 {
+		t.Fatalf("len(chunks) = %d, want 3", len(chunks))
+	}
+
+	wantStarts := []time.Time{
+		time.Date(2026, 6, 7, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 8, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 9, 0, 0, 0, 0, time.UTC),
+	}
+	for i, want := range wantStarts {
+		if chunks[i].ProjectID != "project-1" {
+			t.Fatalf("chunks[%d].ProjectID = %q, want project-1", i, chunks[i].ProjectID)
+		}
+		if !chunks[i].StartDate.Equal(want) {
+			t.Fatalf("chunks[%d].StartDate = %s, want %s", i, chunks[i].StartDate, want)
+		}
+		if !chunks[i].EndDate.Equal(want.AddDate(0, 0, 1)) {
+			t.Fatalf("chunks[%d].EndDate = %s, want %s", i, chunks[i].EndDate, want.AddDate(0, 0, 1))
+		}
+	}
+}
+
+func TestGSCAnalyticsDailyChunksRejectsInvalidRange(t *testing.T) {
+	minDate := time.Date(2026, 6, 9, 0, 0, 0, 0, time.UTC)
+	maxDate := time.Date(2026, 6, 8, 0, 0, 0, 0, time.UTC)
+
+	if chunks := gscAnalyticsDailyChunks("project-1", minDate, maxDate); chunks != nil {
+		t.Fatalf("chunks = %#v, want nil", chunks)
+	}
+	if chunks := gscAnalyticsDailyChunks("", minDate, minDate); chunks != nil {
+		t.Fatalf("chunks = %#v, want nil for empty project", chunks)
+	}
+}


### PR DESCRIPTION
## What changed

- Splits `gsc_analytics` critical-table export into per-project, per-day chunks instead of exporting the whole ClickHouse table in one query.
- Keeps the existing generic export path for the other critical tables.
- Uses typed row scanning for `gsc_analytics` chunks so the export does not hit ClickHouse `String` to `*interface{}` scan conversion issues.
- Adds focused tests for daily chunk generation.

## Why

Large `gsc_analytics` exports can time out when the full table is queried at once. Chunking bounds each ClickHouse query and preserves deterministic export output.

## Validation

- `go test ./internal/storage -run 'TestGSCAnalyticsDailyChunks|TestGSCAnalyticsDailyChunksRejectsInvalidRange'`